### PR TITLE
Make the location of the games configurable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process;
 use structopt::StructOpt;
 
@@ -9,6 +10,9 @@ struct Cli {
 
     #[structopt(long, group = "method", help = "Synchronize over SSH.")]
     ssh: bool,
+
+    #[structopt(long, env = "RETRO_GAMES", help = "The location to synchronize from.")]
+    src: PathBuf,
 
     #[structopt(short, long, help = "The volume or host to synchronize to.")]
     dest: Option<String>,


### PR DESCRIPTION
This adds another CLI argument, `src`, that sets the location of the
games. Its value will be used to drive the list of systems that are
available.

Because I use it elsewhere, the argument can be omitted if the
`$RETRO_GAMES` environment variable is set.
