### PR TITLE
Validate specified systems

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,15 @@ struct Cli {
 fn dispatch() -> Result<(), String> {
     let cli = Cli::from_args();
     println!("{:?}", cli);
+
+    let systems = match validate_systems(cli.src, &cli.system) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(e);
+        }
+    };
+    println!("systems: {:?}", systems);
+
     Ok(())
 }
 
@@ -35,4 +44,14 @@ fn main() {
             1
         }
     });
+}
+
+fn validate_systems(src: PathBuf, systems: &Vec<String>) -> Result<&Vec<String>, String> {
+    for system in systems {
+        if !src.join(system).is_dir() {
+            return Err(format!("'{}' is not a valid system", system));
+        }
+    }
+
+    Ok(systems)
 }


### PR DESCRIPTION
This adds a function that will check that each system specified exists
(where "exists" is defined as "is a directory"). If will return an error
if one is invalid or the systems if they all exist.
