### PR TITLE
Require destination on CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
     src: PathBuf,
 
     #[structopt(short, long, help = "The volume or host to synchronize to.")]
-    dest: Option<String>,
+    dest: String,
 
     #[structopt(short, long, help = "The system to synchronize.")]
     system: Vec<String>,


### PR DESCRIPTION
I never run my current `retro` function without specifying a
destination. Making the argument optional is more trouble than it's
going to be worth. If I find that I ever want to run this without
specifying the destination up front, I can make it optional later.
