### PR TITLE
Validate the method and destination

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,30 @@ struct Cli {
     system: Vec<String>,
 }
 
+enum Method {
+    SD,
+    SSH,
+}
+
 fn dispatch() -> Result<(), String> {
     let cli = Cli::from_args();
     println!("{:?}", cli);
+
+    let method = if cli.sd {
+        Method::SD
+    } else if cli.ssh {
+        Method::SSH
+    } else {
+        return Err("A valid method is required".to_string());
+    };
+
+    let destination = match validate_destination(method, &cli.dest) {
+        Ok(d) => d,
+        Err(e) => {
+            return Err(e);
+        }
+    };
+    println!("destination: {:?}", destination);
 
     let systems = match validate_systems(cli.src, &cli.system) {
         Ok(s) => s,
@@ -44,6 +65,21 @@ fn main() {
             1
         }
     });
+}
+
+fn validate_destination(method: Method, destination: &String) -> Result<&String, String> {
+    match method {
+        Method::SD => {
+            if !PathBuf::from("/Volumes").join(destination).is_dir() {
+                return Err(format!("'{}' is not a valid SD card label", destination));
+            }
+        }
+        Method::SSH => {
+            // There's no great way to check this unless the names are guaranteed to be detined
+            // somewhere. instead just assume that the name is valid.
+        }
+    }
+    Ok(destination)
 }
 
 fn validate_systems(src: PathBuf, systems: &Vec<String>) -> Result<&Vec<String>, String> {


### PR DESCRIPTION
Method and destination validation are being added together because the
two go together. This will ensure that one of `--sd` and `--ssh` is
specified on the CLI (since the CLI doesn't currently enforce this
itself). Based on which method is picked, it will also validate that the
destination exists.

In the case of syncing via SSH, no actual validation of the destination
is done. I could check for a corresponding entry in the SSH config file
(this is how the current `retro` function does it), but this would
exclude the ability to sync to a known host name or IP address. I could
also try to ping the destination, but that is a lot of extra overhead
for successful calls and more or less the same overhead as letting the
sync fail for unsuccessful calls.
