### PR TITLE
Change some of the exits to return Errs

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -1,6 +1,6 @@
 use std::env::set_current_dir;
 use std::path::Path;
-use std::process::{exit, Command};
+use std::process::Command;
 
 use super::config::load_config;
 use super::utils::{capture_output, env_or_exit, find_files};
@@ -47,16 +47,13 @@ fn link(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
 
     let changed = set_current_dir(Path::new(&destination));
     if changed.is_err() {
-        let err = changed.err();
-        eprintln!("{err:#?}");
-        exit(1);
+        return Err(format!("{:#?}", changed.err()));
     };
 
     let config = match load_config(None) {
         Ok(config) => config,
         Err(e) => {
-            eprintln!("{e}");
-            exit(1);
+            return Err(e);
         }
     };
 

--- a/src/onion.rs
+++ b/src/onion.rs
@@ -1,6 +1,6 @@
 use std::env::set_current_dir;
 use std::path::Path;
-use std::process::{exit, Command};
+use std::process::Command;
 
 use super::config::load_config;
 use super::utils::{capture_output, env_or_exit, find_files};
@@ -47,16 +47,13 @@ fn copy(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
 
     let changed = set_current_dir(Path::new(&destination));
     if changed.is_err() {
-        let err = changed.err();
-        eprintln!("{err:#?}");
-        exit(1);
+        return Err(format!("{:#?}", changed.err()));
     };
 
     let config = match load_config(None) {
         Ok(config) => config,
         Err(e) => {
-            eprintln!("{e}");
-            exit(1);
+            return Err(e);
         }
     };
 


### PR DESCRIPTION
This application is structured such that the main entry point returns an
exit code, 0 or 1, based on whether or not the CLI returns an `Ok` or an
`Err`. Ideally this would be the only place this happens. This removes
most of the others. The only one being left for now is the one that is
triggered when a required environment variable isn't set, but this both
simplifies the calling code and includes `or_exit` in its name to
indicate that it could do this.
