### PR TITLE
Merge onion subcommand into link

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,6 @@
 use clap::{Parser, Subcommand};
 
 use super::link;
-use super::onion;
 
 #[derive(Debug, Parser)]
 #[command(name = "retro")]
@@ -14,7 +13,6 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     Link(link::Args),
-    Onion(onion::Args),
 }
 
 pub fn dispatch() -> Result<(), String> {
@@ -22,6 +20,5 @@ pub fn dispatch() -> Result<(), String> {
 
     return match args.command {
         Commands::Link(args) => link::dispatch(args),
-        Commands::Onion(args) => onion::dispatch(args),
     };
 }

--- a/src/games.rs
+++ b/src/games.rs
@@ -1,0 +1,68 @@
+use std::env::set_current_dir;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::config::load_config;
+use super::utils::{capture_output, env_or_exit, find_files};
+
+pub fn link(source: &PathBuf, systems: Vec<String>, all_systems: bool) -> Result<(), String> {
+    let destination = env_or_exit("RETRO_GAMES");
+
+    let changed = set_current_dir(Path::new(&destination));
+    if changed.is_err() {
+        return Err(format!("{:#?}", changed.err()));
+    };
+
+    let config = match load_config(None) {
+        Ok(config) => config,
+        Err(e) => {
+            return Err(e);
+        }
+    };
+
+    let systems_to_link = if all_systems {
+        config.get_system_names()
+    } else {
+        systems
+    };
+
+    for system in systems_to_link {
+        let path = Path::new(&destination).join(&system);
+
+        let system_config = match config.systems.get(&system) {
+            Some(config) => config,
+            None => {
+                eprintln!("{system} not found in config. Skipping.");
+                continue;
+            }
+        };
+
+        let extensions = system_config.get_extensions(system.clone());
+
+        let _ = set_current_dir(&path).is_ok();
+        let mut system_source = Path::new(&source).join(&system_config.dumper).join(&system);
+        if let Some(extra_path) = &system_config.extra_path {
+            system_source = system_source.join(extra_path);
+        }
+        println!("Linking {extensions:?} from {system_source:?} to {path:?}.");
+
+        if !source.is_dir() {
+            eprintln!("{system_source:?} does not exist. Skipping.");
+            continue;
+        }
+
+        let files_to_link = find_files(system_source.clone(), extensions.clone());
+
+        for file in files_to_link {
+            println!(
+                "{}",
+                capture_output(
+                    Command::new("ln").args(["-s", "-F", "-f", "-v", file.to_str().unwrap()]),
+                    "Failed to link"
+                )
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,9 +1,8 @@
-use std::env::set_current_dir;
-use std::path::Path;
-use std::process::Command;
+use std::path::PathBuf;
 
-use super::config::load_config;
-use super::utils::{capture_output, env_or_exit, find_files};
+use super::games;
+use super::onion;
+use super::utils::env_or_exit;
 
 #[derive(Debug, clap::Args)]
 #[command(about = "Link backups")]
@@ -42,64 +41,18 @@ pub fn dispatch(args: Args) -> Result<(), String> {
 }
 
 fn link(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
-    let backup_location = env_or_exit("RETRO_BACKUPS");
-    let destination = env_or_exit("RETRO_GAMES");
+    let backup_location = PathBuf::from(env_or_exit("RETRO_BACKUPS"));
 
-    let changed = set_current_dir(Path::new(&destination));
-    if changed.is_err() {
-        return Err(format!("{:#?}", changed.err()));
-    };
-
-    let config = match load_config(None) {
-        Ok(config) => config,
+    match games::link(&backup_location, systems.clone(), all_systems) {
+        Ok(_) => println!(""),
         Err(e) => {
-            return Err(e);
+            eprintln!("{e:#?}");
         }
-    };
-
-    let systems_to_link = if all_systems {
-        config.get_system_names()
-    } else {
-        systems
-    };
-
-    for system in systems_to_link {
-        let path = Path::new(&destination).join(&system);
-
-        let system_config = match config.systems.get(&system) {
-            Some(config) => config,
-            None => {
-                eprintln!("{system} not found in config. Skipping.");
-                continue;
-            }
-        };
-
-        let extensions = system_config.get_extensions(system.clone());
-
-        let _ = set_current_dir(&path).is_ok();
-        let mut source = Path::new(&backup_location)
-            .join(&system_config.dumper)
-            .join(&system);
-        if let Some(extra_path) = &system_config.extra_path {
-            source = source.join(extra_path);
-        }
-        println!("Linking {extensions:?} from {source:?} to {path:?}.");
-
-        if !source.is_dir() {
-            eprintln!("{source:?} does not exist. Skipping.");
-            continue;
-        }
-
-        let files_to_link = find_files(source.clone(), extensions.clone());
-
-        for file in files_to_link {
-            println!(
-                "{}",
-                capture_output(
-                    Command::new("ln").args(["-s", "-F", "-f", "-v", file.to_str().unwrap()]),
-                    "Failed to link"
-                )
-            );
+    }
+    match onion::copy(&backup_location, systems.clone(), all_systems) {
+        Ok(_) => println!(""),
+        Err(e) => {
+            eprintln!("{e:#?}");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod config;
+mod games;
 mod link;
 mod onion;
 mod utils;


### PR DESCRIPTION
The more I used this application, the more I was reminded that one of my
primary motivations for unifying things was so that I wouldn't have to
run two commands each time I backed up a new game (at least for the
systems that are playable on OnionOS). This merges the `onion`
subcommand into `link`. The latter will now call out to functions that
handle symlinking and copying for the various destinations. It will
gracefully handle trying to sync a system that can't be process through
either of the functions.

There's probably some cleanup that can be done but I wanted to get the
merge itself into a working state first.
