### PR TITLE
Add subcommand to rename bin and cue files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,7 @@ name = "retro"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "glob",
  "serde",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
+glob = "0.3.1"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.6"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 
 use super::link;
+use super::rename;
 
 #[derive(Debug, Parser)]
 #[command(name = "retro")]
@@ -13,6 +14,7 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     Link(link::Args),
+    Rename(rename::Args),
 }
 
 pub fn dispatch() -> Result<(), String> {
@@ -20,5 +22,6 @@ pub fn dispatch() -> Result<(), String> {
 
     return match args.command {
         Commands::Link(args) => link::dispatch(args),
+        Commands::Rename(args) => rename::dispatch(args),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod games;
 mod link;
 mod onion;
+mod rename;
 mod utils;
 
 use std::process::exit;

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -1,0 +1,84 @@
+use std::fs;
+use std::io::prelude::*;
+
+use glob::{glob_with, MatchOptions};
+
+#[derive(Debug, clap::Args)]
+#[command(about = "Rename files")]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[command(flatten)]
+    bin_cue: BinCueArgs,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum Commands {
+    #[command(about = "Rename bin/cue files")]
+    BinCue(BinCueArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct BinCueArgs {
+    #[arg(help = "The current common root of the files to rename")]
+    current: String,
+
+    #[arg(help = "The new common root of the files to rename")]
+    new: String,
+}
+
+pub fn dispatch(args: Args) -> Result<(), String> {
+    let cmd = args.command.unwrap_or(Commands::BinCue(args.bin_cue));
+
+    match cmd {
+        Commands::BinCue(args) => {
+            return rename_bin_cue_files(args.current, args.new);
+        }
+    }
+}
+
+fn rename_bin_cue_files(current_root: String, replacement_root: String) -> Result<(), String> {
+    println!("Renaming all files that start with \"{current_root}\" to \"{replacement_root}\"");
+
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+    for entry in glob_with(&format!("{current_root}*"), options).unwrap() {
+        if let Ok(path) = entry {
+            if path.extension().unwrap() == "cue" {
+                let contents = fs::read_to_string(path.clone()).unwrap();
+                let new = contents.replace(&current_root, &replacement_root);
+                match fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(path.clone())
+                {
+                    Ok(mut file) => {
+                        let _ = file.write(new.as_bytes());
+                    }
+                    Err(e) => {
+                        eprintln!("{e}");
+                    }
+                };
+            }
+
+            let old_name = path.file_name().unwrap();
+            let new_name = old_name
+                .to_str()
+                .unwrap()
+                .replace(&current_root, &replacement_root);
+            match fs::rename(old_name, new_name) {
+                Ok(_) => (),
+                Err(e) => {
+                    eprintln!("{e}");
+                }
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
When I back up CD-based games, they typically come out as bin and cue
files. Unless the dumper is able to identify the game, the files have
generic prefixes (`track` in the case of MPF, `cdrom` in the case of
RetroArch). This subcommand provides a way to mass rename the files by
replacing the common prefix with a new one. More importantly, it will
also do the same to the contents of the cue files, which list out the
related bin files.

Ultimately I'd like to update this to take in a path (e.g., a directory)
and figure out what the common prefix used for all files is, then handle
the rest from there.
