### PR TITLE
Find longest common prefix when renaming files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,12 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +153,6 @@ name = "retro"
 version = "0.1.0"
 dependencies = [
  "clap",
- "glob",
  "serde",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
-glob = "0.3.1"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.6"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,3 +36,78 @@ pub fn find_files(root: PathBuf, extensions: Vec<String>) -> Vec<PathBuf> {
 
     files_found
 }
+
+// Adapted from https://users.rust-lang.org/t/is-this-code-idiomatic/51798/2.
+pub fn longest_common_prefix(vals: &[String]) -> &str {
+    if vals.is_empty() {
+        return "";
+    }
+
+    let common = &vals[0];
+
+    for (i, c) in common.chars().enumerate() {
+        for val in vals {
+            if val.chars().nth(i) != Some(c) {
+                return &common[..i];
+            }
+        }
+    }
+
+    common
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_longest_common_prefix_with_no_strings() {
+        assert_eq!(longest_common_prefix(&[]), "");
+    }
+
+    #[test]
+    fn test_longest_common_prefix_with_one_string() {
+        assert_eq!(longest_common_prefix(&["abc".to_string()]), "abc");
+    }
+
+    #[test]
+    fn test_longest_common_prefix_with_one_string_twice() {
+        assert_eq!(
+            longest_common_prefix(&["abc".to_string(), "abc".to_string()]),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn test_longest_common_prefix_with_one_string_that_is_a_substring_of_the_other() {
+        assert_eq!(
+            longest_common_prefix(&["abc".to_string(), "abcdef".to_string()]),
+            "abc"
+        );
+        assert_eq!(
+            longest_common_prefix(&["abcdef".to_string(), "abc".to_string()]),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn test_longest_common_prefix_with_no_common_prefix() {
+        assert_eq!(
+            longest_common_prefix(&["abc".to_string(), "def".to_string()]),
+            ""
+        );
+    }
+
+    #[test]
+    fn test_longest_common_prefix_with_some_strings() {
+        assert_eq!(
+            longest_common_prefix(&[
+                "abcdef".to_string(),
+                "abcdeg".to_string(),
+                "abcdhi".to_string(),
+                "abcjkl".to_string(),
+            ]),
+            "abc"
+        );
+    }
+}


### PR DESCRIPTION
This simplifies the process of renaming bin and cue files. I will no
longer have to specify the prefix for the files; the application will
figure it out for me.
