### PR TITLE
Add subcommand to compress files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+use super::compress;
 use super::link;
 use super::rename;
 
@@ -13,6 +14,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    Compress(compress::Args),
     Link(link::Args),
     Rename(rename::Args),
 }
@@ -21,6 +23,7 @@ pub fn dispatch() -> Result<(), String> {
     let args = Cli::parse();
 
     return match args.command {
+        Commands::Compress(args) => compress::dispatch(args),
         Commands::Link(args) => link::dispatch(args),
         Commands::Rename(args) => rename::dispatch(args),
     };

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,0 +1,70 @@
+use std::path::PathBuf;
+
+use super::utils::{capture_output, find_files, require_command};
+
+#[derive(Debug, clap::Args)]
+#[command(about = "Compress games")]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[command(flatten)]
+    chd: ChdArgs,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum Commands {
+    #[command(about = "Convert files to CHD")]
+    Chd(ChdArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct ChdArgs {
+    #[arg(help = "The file to compress")]
+    source: PathBuf,
+
+    #[arg(help = "Where to place the compressed file, defaults to the current directory")]
+    dest: Option<PathBuf>,
+}
+
+pub fn dispatch(args: Args) -> Result<(), String> {
+    let cmd = args.command.unwrap_or(Commands::Chd(args.chd));
+    match cmd {
+        Commands::Chd(args) => {
+            return compress_to_chd(args.source, args.dest.clone());
+        }
+    }
+}
+
+fn compress_to_chd(source: PathBuf, dest: Option<PathBuf>) -> Result<(), String> {
+    let output_path = dest.unwrap_or(PathBuf::new());
+    println!("Compressing from {source:?} to {output_path:?}");
+
+    let files_to_compress = find_files(source, vec!["cue".to_string(), "iso".to_string()]);
+
+    for file in files_to_compress {
+        let mut output_file = output_path.join(file.file_name().unwrap());
+        output_file.set_extension("chd");
+        if output_file.exists() {
+            eprintln!("{output_file:?} exists. Skipping.");
+            continue;
+        }
+
+        println!(
+            "{}",
+            capture_output(
+                require_command("chdman").args(vec![
+                    "createcd",
+                    "-i",
+                    file.to_str().unwrap(),
+                    "-o",
+                    output_file.to_str().unwrap(),
+                ]),
+                "Could not compress {file:?}",
+            )
+        );
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod compress;
 mod config;
 mod games;
 mod link;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -111,3 +111,13 @@ mod test {
         );
     }
 }
+
+pub fn require_command(command: &str) -> Command {
+    if let Ok(output) = Command::new("which").arg(command).output() {
+        if output.status.success() {
+            return Command::new(command);
+        }
+    }
+
+    panic!("{command} not found");
+}


### PR DESCRIPTION
This command can be used to compress cue and iso files to chd. It takes
a directory as input and will find all cue and iso files in it. It
optionally takes a directory for where to store the output. It will skip
any files for which a chd already exists in the output directory.

Some day I'd like to be able to compress to other formats as well, such
as rvz.
