### PR TITLE
Add subcommand to generate playlist files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,10 +158,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "retro"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "regex",
  "serde",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
+regex = "1.10.2"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.6"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 use super::compress;
 use super::link;
+use super::playlist;
 use super::rename;
 
 #[derive(Debug, Parser)]
@@ -16,6 +17,7 @@ struct Cli {
 enum Commands {
     Compress(compress::Args),
     Link(link::Args),
+    Playlist(playlist::Args),
     Rename(rename::Args),
 }
 
@@ -25,6 +27,7 @@ pub fn dispatch() -> Result<(), String> {
     return match args.command {
         Commands::Compress(args) => compress::dispatch(args),
         Commands::Link(args) => link::dispatch(args),
+        Commands::Playlist(args) => playlist::dispatch(args),
         Commands::Rename(args) => rename::dispatch(args),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod games;
 mod link;
 mod onion;
+mod playlist;
 mod rename;
 mod utils;
 

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+use regex::Regex;
+
+use super::utils::find_files;
+
+#[derive(Debug, clap::Args)]
+#[command(about = "Create playlist files for multidisc games")]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[command(flatten)]
+    generate: GenerateArgs,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum Commands {
+    #[command(about = "Generate playlist files for multidisc games")]
+    Generate(GenerateArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct GenerateArgs {
+    #[arg(help = "The location to check for files")]
+    source: PathBuf,
+}
+
+pub fn dispatch(args: Args) -> Result<(), String> {
+    let cmd = args.command.unwrap_or(Commands::Generate(args.generate));
+    match cmd {
+        Commands::Generate(args) => {
+            return generate_m3u_playlists(args.source);
+        }
+    }
+}
+
+fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
+    println!("Generating playlists for files in {source:?}");
+
+    let re = Regex::new(r"(?<before>.+) \(Disc (?<disc>\d+)\)(?<after>.*)\.[^.]+$").unwrap();
+
+    let mut matches: HashMap<String, Vec<String>> = HashMap::new();
+
+    for file in find_files(source.clone(), vec!["chd".to_string()]) {
+        let file_name = file.file_name().unwrap().to_str().unwrap();
+        let capture = re.captures(file_name);
+        if let Some(capture) = capture {
+            let before = capture.name("before").unwrap().as_str().to_string();
+            let after = capture.name("after").unwrap().as_str().to_string();
+            matches
+                .entry(format!("{before}{after}"))
+                .or_insert_with(|| vec![])
+                .push(capture.get(0).unwrap().as_str().to_string())
+        }
+    }
+
+    for (playlist, files) in &matches {
+        let playlist_file = source.join(playlist).with_extension("m3u");
+        if playlist_file.exists() {
+            continue;
+        }
+
+        let mut f = File::create(playlist_file).expect("Unable to create playlist");
+        for file in files {
+            let _ = f.write_all(&file.clone().into_bytes());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Many emulators for disc-based games support the use of playlist files
for multidisc games. This adds a `playlist` subcommand that will
generate missing playlist files for the specified directory.
