### PR TITLE
Add output when generating a playlist

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -65,6 +65,8 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
             continue;
         }
 
+        println!("Generating {playlist_file:?}");
+
         let mut f = File::create(playlist_file).expect("Unable to create playlist");
         for file in files {
             let _ = f.write_all(&file.clone().into_bytes());


### PR DESCRIPTION
Most other commands produce some sort of output. This one just sort of
ends. This adds a change to prints to stdout whenever a playlist file is
going to be generated.
