### PR TITLE
Show errors when playlist file can't be written to

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -67,9 +67,14 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
 
         println!("Generating {playlist_file:?}");
 
-        let mut f = File::create(playlist_file).expect("Unable to create playlist");
+        let mut f = File::create(playlist_file.clone()).expect("Unable to create playlist");
         for file in files {
-            let _ = f.write_all(&file.clone().into_bytes());
+            match f.write_all(&file.clone().into_bytes()) {
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("{e}");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I'm not entirely sure when this would happen, but if there's an error
writing a line to a playlist file, I'd like to know about it.
