### PR TITLE
Prefer slices to vectors

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -41,7 +41,7 @@ fn compress_to_chd(source: PathBuf, dest: Option<PathBuf>) -> Result<(), String>
     let output_path = dest.unwrap_or(PathBuf::new());
     println!("Compressing from {source:?} to {output_path:?}");
 
-    let files_to_compress = find_files(source, vec!["cue".to_string(), "iso".to_string()]);
+    let files_to_compress = find_files(source, &["cue".to_string(), "iso".to_string()]);
 
     for file in files_to_compress {
         let mut output_file = output_path.join(file.file_name().unwrap());
@@ -54,7 +54,7 @@ fn compress_to_chd(source: PathBuf, dest: Option<PathBuf>) -> Result<(), String>
         println!(
             "{}",
             capture_output(
-                require_command("chdman").args(vec![
+                require_command("chdman").args(&[
                     "createcd",
                     "-i",
                     file.to_str().unwrap(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ impl Config {
 // instances of the struct so that 1) `system` doesn't need to be passed in as an argument and 2) I
 // don't have to resort to requiring `destination` and `extension` in each config entry.
 impl System {
-    pub fn get_destinations(&self, system: String) -> Vec<String> {
+    pub fn get_destinations(&self, system: &String) -> Vec<String> {
         let destinations = if self.destinations.is_some() {
             self.destinations.clone().unwrap()
         } else {
@@ -38,11 +38,11 @@ impl System {
         destinations
     }
 
-    pub fn get_extensions(&self, system: String) -> Vec<String> {
+    pub fn get_extensions(&self, system: &String) -> Vec<String> {
         let extensions = if self.extensions.is_some() {
             self.extensions.clone().unwrap()
         } else {
-            vec![self.extension.clone().unwrap_or(system)]
+            vec![self.extension.clone().unwrap_or(system.to_string())]
         };
 
         extensions
@@ -103,16 +103,16 @@ mod tests {
 
     #[test]
     fn system_get_destinations_uses_destinations_first() {
-        let destinations = vec!["b".to_string(), "c".to_string()];
+        let destinations = &["b".to_string(), "c".to_string()];
         let system = System {
             destination: Some("a".to_string()),
-            destinations: Some(destinations.clone()),
+            destinations: Some(destinations.to_vec()),
             dumper: "".to_string(),
             extension: None,
             extensions: None,
             extra_path: None,
         };
-        assert_eq!(system.get_destinations("".to_string()), destinations);
+        assert_eq!(system.get_destinations(&"".to_string()), destinations);
     }
 
     #[test]
@@ -125,10 +125,7 @@ mod tests {
             extensions: None,
             extra_path: None,
         };
-        assert_eq!(
-            system.get_destinations("".to_string()),
-            vec!["a".to_string()]
-        );
+        assert_eq!(system.get_destinations(&"".to_string()), &["a".to_string()]);
     }
 
     #[test]
@@ -141,21 +138,21 @@ mod tests {
             extensions: None,
             extra_path: None,
         };
-        assert_eq!(system.get_destinations("abc".to_string()), vec!["ABC"]);
+        assert_eq!(system.get_destinations(&"abc".to_string()), &["ABC"]);
     }
 
     #[test]
     fn system_get_extensions_uses_extensions_first() {
-        let extensions = vec!["b".to_string(), "c".to_string()];
+        let extensions = &["b".to_string(), "c".to_string()];
         let system = System {
             destination: None,
             destinations: None,
             dumper: "".to_string(),
             extension: Some("a".to_string()),
-            extensions: Some(extensions.clone()),
+            extensions: Some(extensions.to_vec()),
             extra_path: None,
         };
-        assert_eq!(system.get_extensions("".to_string()), extensions);
+        assert_eq!(system.get_extensions(&"".to_string()), extensions);
     }
 
     #[test]
@@ -168,7 +165,7 @@ mod tests {
             extensions: None,
             extra_path: None,
         };
-        assert_eq!(system.get_extensions("".to_string()), vec!["a".to_string()]);
+        assert_eq!(system.get_extensions(&"".to_string()), &["a".to_string()]);
     }
 
     #[test]
@@ -181,6 +178,6 @@ mod tests {
             extensions: None,
             extra_path: None,
         };
-        assert_eq!(system.get_extensions("abc".to_string()), vec!["abc"]);
+        assert_eq!(system.get_extensions(&"abc".to_string()), &["abc"]);
     }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -43,13 +43,13 @@ pub fn dispatch(args: Args) -> Result<(), String> {
 fn link(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
     let backup_location = PathBuf::from(env_or_exit("RETRO_BACKUPS"));
 
-    match games::link(&backup_location, systems.clone(), all_systems) {
+    match games::link(&backup_location, &systems, all_systems) {
         Ok(_) => println!(""),
         Err(e) => {
             eprintln!("{e:#?}");
         }
     }
-    match onion::copy(&backup_location, systems.clone(), all_systems) {
+    match onion::copy(&backup_location, &systems, all_systems) {
         Ok(_) => println!(""),
         Err(e) => {
             eprintln!("{e:#?}");

--- a/src/onion.rs
+++ b/src/onion.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use super::config::load_config;
 use super::utils::{capture_output, env_or_exit, find_files};
 
-pub fn copy(source: &PathBuf, systems: Vec<String>, all_systems: bool) -> Result<(), String> {
+pub fn copy(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(), String> {
     let destination = env_or_exit("ONION_GAMES");
 
     let changed = set_current_dir(Path::new(&destination));
@@ -20,14 +20,15 @@ pub fn copy(source: &PathBuf, systems: Vec<String>, all_systems: bool) -> Result
         }
     };
 
+    let configured_systems = config.get_system_names();
     let systems_to_copy = if all_systems {
-        config.get_system_names()
+        &configured_systems
     } else {
         systems
     };
 
     for system in systems_to_copy {
-        let system_config = match config.systems.get(&system) {
+        let system_config = match config.systems.get(system) {
             Some(config) => config,
             None => {
                 eprintln!("{system} not found in config. Skipping.");
@@ -41,9 +42,9 @@ pub fn copy(source: &PathBuf, systems: Vec<String>, all_systems: bool) -> Result
             continue;
         }
 
-        let extensions = system_config.get_extensions(system.clone());
+        let extensions = system_config.get_extensions(system);
 
-        let files_to_copy = find_files(system_source.clone(), extensions.clone());
+        let files_to_copy = find_files(system_source.clone(), &extensions);
 
         let destinations = system_config.get_destinations(system);
         for copy_destination in destinations {

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -46,7 +46,7 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
 
     let mut matches: HashMap<String, Vec<String>> = HashMap::new();
 
-    for file in find_files(source.clone(), vec!["chd".to_string()]) {
+    for file in find_files(source.clone(), &["chd".to_string()]) {
         let file_name = file.file_name().unwrap().to_str().unwrap();
         let capture = re.captures(file_name);
         if let Some(capture) = capture {

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -52,7 +52,7 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     println!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
 
     let mut file_names = Vec::new();
-    for file in find_files(source.clone(), vec!["bin".to_string(), "cue".to_string()]) {
+    for file in find_files(source.clone(), &["bin".to_string(), "cue".to_string()]) {
         if let Some(file_name) = file.file_name() {
             file_names.push(file_name.to_str().unwrap().to_string());
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,7 +21,7 @@ pub fn env_or_exit(name: &str) -> String {
     };
 }
 
-pub fn find_files(root: PathBuf, extensions: Vec<String>) -> Vec<PathBuf> {
+pub fn find_files(root: PathBuf, extensions: &[String]) -> Vec<PathBuf> {
     let mut files_found = Vec::new();
     for file in root.read_dir().unwrap() {
         let path = file.unwrap().path();


### PR DESCRIPTION
Using vectors requires ownership of the memory. Using slices borrows the
memory. While I still need to use vectors for the CLI and when
populating structs from TOML, almost every other place that I use a
vector can be simplified by using a slice instead.

One place that feels like a sideways step is when determining the list
of systems. Once the `if` block is done, the memory used for
`config.get_system_names` is freed, so the memory needs to be claimed
beforehand.
