### PR TITLE
Stream output when compressing

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::utils::{capture_output, find_files, require_command};
+use super::utils::{find_files, require_command, stream_output};
 
 #[derive(Debug, clap::Args)]
 #[command(about = "Compress games")]
@@ -51,18 +51,15 @@ fn compress_to_chd(source: PathBuf, dest: Option<PathBuf>) -> Result<(), String>
             continue;
         }
 
-        println!(
-            "{}",
-            capture_output(
-                require_command("chdman").args(&[
-                    "createcd",
-                    "-i",
-                    file.to_str().unwrap(),
-                    "-o",
-                    output_file.to_str().unwrap(),
-                ]),
-                "Could not compress {file:?}",
-            )
+        stream_output(
+            require_command("chdman").args(&[
+                "createcd",
+                "-i",
+                file.to_str().unwrap(),
+                "-o",
+                output_file.to_str().unwrap(),
+            ]),
+            "Could not compress {file:?}",
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -121,3 +121,11 @@ pub fn require_command(command: &str) -> Command {
 
     panic!("{command} not found");
 }
+
+pub fn stream_output(command: &mut Command, expected_message: &str) {
+    let mut child = command.spawn().expect(expected_message);
+    let exit_status = child.wait().expect(expected_message);
+    if !exit_status.success() {
+        exit(exit_status.code().unwrap());
+    }
+}


### PR DESCRIPTION
`chdman` streams its output, updating the completion percentage as it
goes. When the output is captured and printed only after the command
completes, this real-time information is lost.

This adds a `stream_output` function that works similarly to
`capture_output`, except, it will allow the running process to write
directly to stdout. It will also exit with the process's exit code if
it's non-zero.
