### PR TITLE
Add an m3u alias for the playlist command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ struct Cli {
 enum Commands {
     Compress(compress::Args),
     Link(link::Args),
+    #[clap(visible_alias = "m3u")]
     Playlist(playlist::Args),
     Rename(rename::Args),
 }


### PR DESCRIPTION
I like to use meaningful names for my commands, but `playlist` is long
compared to `m3u`. And the latter is how I often mentally think of the
command. This adds an alias so that either will work. It's being added
as a visible alias so that it's discoverable in the help text.
