### PR TITLE
Add an chd alias for the compress command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    #[clap(visible_alias = "chd")]
     Compress(compress::Args),
     Link(link::Args),
     #[clap(visible_alias = "m3u")]


### PR DESCRIPTION
Just like in 1665b5b, `compress` is long compared to `chd`. And the
latter is how I often mentally think of the command. This adds an alias
so that either will work. It's being added as a visible alias so that
it's discoverable in the help text.
