### PR TITLE
Add a verbosity flag to the command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "clap"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,16 @@ checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fdbb015d790cfb378aca82caf9cc52a38be96a7eecdb92f31b4366a8afc019"
+dependencies = [
+ "clap",
+ "log",
 ]
 
 [[package]]
@@ -106,10 +122,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "hashbrown"
@@ -124,6 +163,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "indexmap"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +183,35 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -191,9 +271,25 @@ name = "retro"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap-verbosity-flag",
+ "env_logger",
+ "log",
  "regex",
  "serde",
  "toml",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -243,6 +339,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +392,37 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
+clap-verbosity-flag = "2.1.0"
+env_logger = "0.10.1"
+log = "0.4.20"
 regex = "1.10.2"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.6"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,7 @@
 use clap::{Parser, Subcommand};
+use clap_verbosity_flag::Verbosity;
+
+use env_logger;
 
 use super::compress;
 use super::link;
@@ -11,6 +14,9 @@ use super::rename;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+
+    #[command(flatten)]
+    verbose: Verbosity,
 }
 
 #[derive(Debug, Subcommand)]
@@ -25,6 +31,13 @@ enum Commands {
 
 pub fn dispatch() -> Result<(), String> {
     let args = Cli::parse();
+
+    env_logger::Builder::new()
+        .filter_level(args.verbose.log_level_filter())
+        .format_level(false)
+        .format_target(false)
+        .format_timestamp(None)
+        .init();
 
     return match args.command {
         Commands::Compress(args) => compress::dispatch(args),

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use log::{debug, warn};
+
 use super::utils::{find_files, require_command, stream_output};
 
 #[derive(Debug, clap::Args)]
@@ -39,7 +41,7 @@ pub fn dispatch(args: Args) -> Result<(), String> {
 
 fn compress_to_chd(source: PathBuf, dest: Option<PathBuf>) -> Result<(), String> {
     let output_path = dest.unwrap_or(PathBuf::new());
-    println!("Compressing from {source:?} to {output_path:?}");
+    debug!("Compressing from {source:?} to {output_path:?}");
 
     let files_to_compress = find_files(source, &["cue".to_string(), "iso".to_string()]);
 
@@ -47,7 +49,7 @@ fn compress_to_chd(source: PathBuf, dest: Option<PathBuf>) -> Result<(), String>
         let mut output_file = output_path.join(file.file_name().unwrap());
         output_file.set_extension("chd");
         if output_file.exists() {
-            eprintln!("{output_file:?} exists. Skipping.");
+            warn!("{output_file:?} exists. Skipping.");
             continue;
         }
 

--- a/src/games.rs
+++ b/src/games.rs
@@ -2,6 +2,8 @@ use std::env::set_current_dir;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use log::{debug, info, warn};
+
 use super::config::load_config;
 use super::utils::{capture_output, env_or_exit, find_files};
 
@@ -33,7 +35,7 @@ pub fn link(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
         let system_config = match config.systems.get(system) {
             Some(config) => config,
             None => {
-                eprintln!("{system} not found in config. Skipping.");
+                warn!("{system} not found in config. Skipping.");
                 continue;
             }
         };
@@ -46,17 +48,17 @@ pub fn link(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
             path = path.join(extra_path);
         }
         let _ = set_current_dir(&path).is_ok();
-        println!("Linking {extensions:?} from {system_source:?} to {path:?}.");
+        debug!("Linking {extensions:?} from {system_source:?} to {path:?}.");
 
         if !source.is_dir() {
-            eprintln!("{system_source:?} does not exist. Skipping.");
+            warn!("{system_source:?} does not exist. Skipping.");
             continue;
         }
 
         let files_to_link = find_files(system_source.clone(), &extensions);
 
         for file in files_to_link {
-            println!(
+            info!(
                 "{}",
                 capture_output(
                     Command::new("ln").args(["-s", "-F", "-f", "-v", file.to_str().unwrap()]),

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use log::{error, info};
+
 use super::games;
 use super::onion;
 use super::utils::env_or_exit;
@@ -44,19 +46,20 @@ fn link(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
     let backup_location = PathBuf::from(env_or_exit("RETRO_BACKUPS"));
 
     match games::link(&backup_location, &systems, all_systems) {
-        Ok(_) => println!(""),
+        Ok(_) => info!(""),
         Err(e) => {
-            eprintln!("{e:#?}");
+            error!("{e:#?}");
         }
     }
     match onion::copy(&backup_location, &systems, all_systems) {
-        Ok(_) => println!(""),
+        Ok(_) => info!(""),
         Err(e) => {
-            eprintln!("{e:#?}");
+            error!("{e:#?}");
         }
     }
 
-    println!("Done.");
+    // This isn't really an error but I currently want it to appear unless output is suppressed.
+    error!("Done.");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,13 @@ mod utils;
 
 use std::process::exit;
 
+use log::error;
+
 fn main() {
     exit(match cli::dispatch() {
         Ok(_) => 0,
         Err(e) => {
-            eprintln!("error: {:?}", e);
+            error!("error: {:?}", e);
             1
         }
     });

--- a/src/onion.rs
+++ b/src/onion.rs
@@ -2,6 +2,8 @@ use std::env::set_current_dir;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use log::{debug, info, warn};
+
 use super::config::load_config;
 use super::utils::{capture_output, env_or_exit, find_files};
 
@@ -31,14 +33,14 @@ pub fn copy(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
         let system_config = match config.systems.get(system) {
             Some(config) => config,
             None => {
-                eprintln!("{system} not found in config. Skipping.");
+                warn!("{system} not found in config. Skipping.");
                 continue;
             }
         };
 
         let system_source = Path::new(&source).join(&system_config.dumper).join(&system);
         if !system_source.is_dir() {
-            eprintln!("{system_source:?} does not exist. Skipping.");
+            warn!("{system_source:?} does not exist. Skipping.");
             continue;
         }
 
@@ -49,7 +51,7 @@ pub fn copy(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
         let destinations = system_config.get_destinations(system);
         for copy_destination in destinations {
             let path = Path::new(&destination).join(copy_destination);
-            println!("Copying {extensions:?} from {system_source:?} to {path:?}.");
+            debug!("Copying {extensions:?} from {system_source:?} to {path:?}.");
 
             let mut command = Command::new("rsync");
             command.args([
@@ -65,7 +67,7 @@ pub fn copy(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
             command.args(files_to_copy.clone());
             command.arg(path.to_str().unwrap());
 
-            println!("{}", capture_output(&mut command, "Failed to copy"));
+            info!("{}", capture_output(&mut command, "Failed to copy"));
         }
     }
 

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -3,6 +3,8 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+use log::{debug, error, info};
+
 use regex::Regex;
 
 use super::utils::find_files;
@@ -40,7 +42,7 @@ pub fn dispatch(args: Args) -> Result<(), String> {
 }
 
 fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
-    println!("Generating playlists for files in {source:?}");
+    debug!("Generating playlists for files in {source:?}");
 
     let re = Regex::new(r"(?<before>.+) \(Disc (?<disc>\d+)\)(?<after>.*)\.[^.]+$").unwrap();
 
@@ -65,14 +67,14 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
             continue;
         }
 
-        println!("Generating {playlist_file:?}");
+        info!("Generating {playlist_file:?}");
 
         let mut f = File::create(playlist_file.clone()).expect("Unable to create playlist");
         for file in files {
             match f.write_all(&file.clone().into_bytes()) {
                 Ok(_) => {}
                 Err(e) => {
-                    eprintln!("{e}");
+                    error!("{e}");
                 }
             }
         }

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::io::prelude::*;
 use std::path::PathBuf;
 
+use log::{debug, error};
+
 use super::utils::{find_files, longest_common_prefix};
 
 #[derive(Debug, clap::Args)]
@@ -49,7 +51,7 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
             .unwrap()
             .to_string(),
     };
-    println!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
+    debug!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
 
     let mut file_names = Vec::new();
     for file in find_files(source.clone(), &["bin".to_string(), "cue".to_string()]) {
@@ -71,7 +73,7 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
         match fs::rename(old_path, new_path.clone()) {
             Ok(_) => (),
             Err(e) => {
-                eprintln!("{e}");
+                error!("{e}");
             }
         }
 
@@ -87,7 +89,7 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
                     let _ = file.write(new.as_bytes());
                 }
                 Err(e) => {
-                    eprintln!("{e}");
+                    error!("{e}");
                 }
             };
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@ use std::env::var;
 use std::path::PathBuf;
 use std::process::{exit, Command};
 
+use log::error;
+
 pub fn capture_output<'a>(command: &'a mut Command, expected_message: &'a str) -> String {
     let output = command.output().expect(expected_message);
     let result = match String::from_utf8(output.stdout) {
@@ -15,7 +17,7 @@ pub fn env_or_exit(name: &str) -> String {
     return match var(name) {
         Ok(value) => value,
         Err(error) => {
-            eprintln!("{name:?}: {error}");
+            error!("{name:?}: {error}");
             exit(1);
         }
     };


### PR DESCRIPTION
The output produced by this tool can sometimes be a bit much. I've
decided to add a verbosity flag to help control this. Fortunately,
there's a [clap_verbosity_flag] crate that does most of the heavy
lifting for me. It requires switching from `println` and `eprintln` to a
logger, but this is probably for the best. I've stripped out the
logger's prefix and done by best to match the current experience,
adjusting a few log levels here and there.

I plan to follow this up with a change that will take advantage of the
flag to control the streaming output as well.
