### PR TITLE
Use the verbosity flag to suppress chdman output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,15 +32,17 @@ enum Commands {
 pub fn dispatch() -> Result<(), String> {
     let args = Cli::parse();
 
+    let log_level = args.verbose.log_level_filter();
+
     env_logger::Builder::new()
-        .filter_level(args.verbose.log_level_filter())
+        .filter_level(log_level)
         .format_level(false)
         .format_target(false)
         .format_timestamp(None)
         .init();
 
     return match args.command {
-        Commands::Compress(args) => compress::dispatch(args),
+        Commands::Compress(args) => compress::dispatch(args, log_level),
         Commands::Link(args) => link::dispatch(args),
         Commands::Playlist(args) => playlist::dispatch(args),
         Commands::Rename(args) => rename::dispatch(args),


### PR DESCRIPTION
The output from chdman can be useful, but it isn't always something I
want to see. This uses the verbosity flag to either stream the output
(the current behavior), suppress the output, or display a completion
message (the default).

A change to the API of a single `dispatch` function is being introduced
here. I don't think I like the idea of them not all having the same
arguments anymore, but I don't yet need it for any of the other commands
so I'm going to leave it for now, and revisit this if/when I come up
with other uses.
