### PR TITLE
Check for existence of correct system source

### DIFF
--- a/src/games.rs
+++ b/src/games.rs
@@ -50,7 +50,7 @@ pub fn link(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
         let _ = set_current_dir(&path).is_ok();
         debug!("Linking {extensions:?} from {system_source:?} to {path:?}.");
 
-        if !source.is_dir() {
+        if !system_source.is_dir() {
             warn!("{system_source:?} does not exist. Skipping.");
             continue;
         }


### PR DESCRIPTION
When linking games, this tool checks for the existence of each system's
source before trying to sync it. While merging the code for linking
games for Onion into the code that handles my general game linking, I
renamed a variable. Unfortunately, I missed one reference to the
variable: the one used for the actual check. This updates that to avoid
a panic when I try to link a system that doesn't have a source.
