### PR TITLE
Make some output a little easier to read

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -49,7 +49,7 @@ fn compress_to_chd(source: PathBuf, dest: Option<PathBuf>) -> Result<(), String>
         let mut output_file = output_path.join(file.file_name().unwrap());
         output_file.set_extension("chd");
         if output_file.exists() {
-            warn!("{output_file:?} exists. Skipping.");
+            warn!("{} exists. Skipping.", output_file.display());
             continue;
         }
 

--- a/src/games.rs
+++ b/src/games.rs
@@ -51,7 +51,7 @@ pub fn link(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
         debug!("Linking {extensions:?} from {system_source:?} to {path:?}.");
 
         if !system_source.is_dir() {
-            warn!("{system_source:?} does not exist. Skipping.");
+            warn!("{} does not exist. Skipping.", system_source.display());
             continue;
         }
 

--- a/src/onion.rs
+++ b/src/onion.rs
@@ -40,7 +40,7 @@ pub fn copy(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
 
         let system_source = Path::new(&source).join(&system_config.dumper).join(&system);
         if !system_source.is_dir() {
-            warn!("{system_source:?} does not exist. Skipping.");
+            warn!("{} does not exist. Skipping.", system_source.display());
             continue;
         }
 


### PR DESCRIPTION
When a `PathBuf` is formatted using the `Debug` trait, it escapes
characters like apostrophes. This can cause it to look a little off at
times. This switches some logging messages to use the `Display` trait
instead. The one downside is that the whole value is no longer wrapped
in quotes, but that's easy enough to add myself if it ends up bothering
me.
