### PR TITLE
Link games regardless of log level

### DIFF
--- a/src/games.rs
+++ b/src/games.rs
@@ -58,13 +58,11 @@ pub fn link(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
         let files_to_link = find_files(system_source.clone(), &extensions);
 
         for file in files_to_link {
-            info!(
-                "{}",
-                capture_output(
-                    Command::new("ln").args(["-s", "-F", "-f", "-v", file.to_str().unwrap()]),
-                    "Failed to link"
-                )
+            let output = capture_output(
+                Command::new("ln").args(["-s", "-F", "-f", "-v", file.to_str().unwrap()]),
+                "Failed to link",
             );
+            info!("{output}");
         }
     }
 

--- a/src/onion.rs
+++ b/src/onion.rs
@@ -67,7 +67,8 @@ pub fn copy(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
             command.args(files_to_copy.clone());
             command.arg(path.to_str().unwrap());
 
-            info!("{}", capture_output(&mut command, "Failed to copy"));
+            let output = capture_output(&mut command, "Failed to copy");
+            info!("{output}");
         }
     }
 


### PR DESCRIPTION
It turns out the logging macros are smart enough to not execute any
calls being passed in as arguments if logs of the specified level would
not be logged. This means that calling games won't be linked if the log
level is anything less than `info`. This moves the `capture_output`
calls to separate lines with assignments.
