### PR TITLE
Don't symlink games that are already symlinked

### DIFF
--- a/src/onion.rs
+++ b/src/onion.rs
@@ -2,7 +2,7 @@ use std::env::set_current_dir;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use log::{debug, info, warn};
+use log::{debug, warn};
 
 use super::config::load_config;
 use super::utils::{capture_output, env_or_exit, find_files};
@@ -68,7 +68,7 @@ pub fn copy(source: &PathBuf, systems: &[String], all_systems: bool) -> Result<(
             command.arg(path.to_str().unwrap());
 
             let output = capture_output(&mut command, "Failed to copy");
-            info!("{output}");
+            warn!("{output}");
         }
     }
 


### PR DESCRIPTION
This will check for and resolve symlinks that already exist in the
destination folder when linking games and skip any that already
reference the game being linked.

The log message about creating a link is being promoted from `info` to
`warn` with logs about skipping being handled as `info`. For
consistency, the output from `rsync` for Onion games is also being
promoted to `warn`.
