### PR TITLE
Allow renaming with or without a trailing slash

### DIFF
--- a/src/rename.rs
+++ b/src/rename.rs
@@ -44,12 +44,10 @@ pub fn dispatch(args: Args) -> Result<(), String> {
 fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Result<(), String> {
     let new_prefix = match replacement_root {
         Some(replacement_root) => replacement_root,
-        None => source
-            .to_str()
-            .unwrap()
-            .strip_suffix("/")
-            .unwrap()
-            .to_string(),
+        None => {
+            let tmp = source.to_str().unwrap();
+            tmp.strip_suffix("/").unwrap_or(tmp).to_string()
+        }
     };
     debug!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
 


### PR DESCRIPTION
When I made the rename subcommand use the source's name as the default
in cfbdd27, I made it work with trailing slashes in the name.
Unfortunately I seem to have forgotten to test it without a trailing
slash. `strip_suffix` can't be unwrapped when the suffix isn't found. I
thought it would return the original value unmodified. This lead to a
panic when the source didn't include a trailing slash and no specific
destination value was provided. This recreates that logic using
`unwrap_or`.
