### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      separator: "-"
+
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
I noticed that the GitHub's checkout action was behind and realized I'd
never set up Dependabot for this project. This adds a basic
`dependabot.yml` file to turn it on and start keeping things, including
the project's dependencies, up-to-date.