### PR TITLE
Build on release instead of push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,8 @@ permissions:
   contents: write
 
 on:
-  # Only run the workflow for pushes to the default branch.
-  push:
-    branches:
-      - main
+  release:
+    types: [created]
 
   # Allow the workflow to be triggered manually from the Actions tab.
   workflow_dispatch:


### PR DESCRIPTION
[create-gh-release-action] only supports building for releases, not for
branches. This changes the build trigger to the create of a tag instead
of a push to `main`.

[create-gh-release-action]: https://github.com/taiki-e/create-gh-release-action