### PR TITLE
Update clap and its related libraries together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
       interval: "weekly"
     pull-request-branch-name:
       separator: "-"
+    groups:
+      clap:
+        patterns:
+          - "clap*"


### PR DESCRIPTION
Rather than sending separate updates for clap and clap-related
libraries, I'd like dependabot to update them together.