### PR TITLE
Rename release action to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 ---
-name: Release
+name: Build
 
 permissions:
   contents: write


### PR DESCRIPTION
As a followup to #41, the build action's name (as shown in GitHub
Actions) is being renamed to better reflects what it's doing.