### PR TITLE
Add Action to create a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+---
+name: Release
+
+on:
+  # Only run the workflow for pushes to the default branch.
+  push:
+    branches:
+      - main
+
+  # Allow the workflow to be triggered manually from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: elgohr/Github-Release-Action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Latest release"


### PR DESCRIPTION
This uses [marvinpinto/action-automatic-releases] to generate a release.
It will run each time something is pushed to `main`. This should allow
the build action to run.

[marvinpinto/action-automatic-releases]: https://github.com/marvinpinto/action-automatic-releases