### PR TITLE
Grant write permission to the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 ---
 name: Release
 
+permissions:
+  contents: write
+
 on:
   # Only run the workflow for pushes to the default branch.
   push:


### PR DESCRIPTION
When the release action ran, it received an error.

   Resource not accessible by integration

This seems related to the `GITHUB_TOKEN` having read-only permission by
default. I don't want to change that, so this explicitly adds write
permission to the action itself.