### PR TITLE
Add action to create tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,25 @@
+---
+name: Tag
+
+permissions:
+  contents: write
+
+on:
+  # Only run the workflow for pushes to the default branch.
+  push:
+    branches:
+      - main
+
+  # Allow the workflow to be triggered manually from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This uses [mathieudutour/github-tag-action] to generate a new tag each
time something is pushed to `main`. This should trigger the release
action.

[mathieudutour/github-tag-action]: https://github.com/mathieudutour/github-tag-action