### PR TITLE
Use GitHub script for creating tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,6 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mathieudutour/github-tag-action@v6.1
+      # https://stackoverflow.com/a/77680570/978961
+      - uses: actions/github-script@v6
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ steps.extract-version.outputs.VERSION }}',
+              sha: context.sha
+            })


### PR DESCRIPTION
Rather than using an action that doesn't behave exactly the way I want
it to -- in this case it used a version number for the tag, but the
number wasn't really based on anything -- this will use a GitHub script
to create the tag and name it after the hash of the commit being used.