### PR TITLE
Actually use hash for tag name

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -27,6 +27,6 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/v${{ steps.extract-version.outputs.VERSION }}',
+              ref: 'refs/tags/${{ context.sha }}',
               sha: context.sha
             })


### PR DESCRIPTION
Oops. I misread the code I used to create the tag. It was using a
version number that came from elsewhere in the original build process
referenced on Stack Overflow. This should use the hash instead.