### PR TITLE
Properly reference hash for tag name

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -27,6 +27,6 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/${{ context.sha }}',
+              ref: 'refs/tags/' + context.sha,
               sha: context.sha
             })


### PR DESCRIPTION
Oops again. I referenced the hash like it was coming from the GitHub
environment. Really it's already available inside the script itself.
This just concatenates it to the rest of the tag name.