### PR TITLE
Use a valid name for tags

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -27,6 +27,6 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/' + context.sha,
+              ref: 'refs/tags/auto-' + context.sha,
               sha: context.sha
             })


### PR DESCRIPTION
GitHub wisely doesn't allow 40-character hexadecimal strings to be used
for the names as tags. It's especially silly of me to think that I'd be
able to create a tag with the same name as a commit's hash. I've decided
to use "auto-" as a prefix so that the release action can watch for it.
