### PR TITLE
Run the release action for tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,9 @@ permissions:
   contents: write
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - auto-*
 
   # Allow the workflow to be triggered manually from the Actions tab.
   workflow_dispatch:


### PR DESCRIPTION
Instead of running on releases -- which aren't currently being made --
this will run the release action for the tags that are automatically
generated by the tag action.