### PR TITLE
Use correct name to get hash in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/create-gh-release-action@v1
         with:
-          ref: refs/tag/auto-${{ context.sha }}
+          ref: refs/tag/auto-${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-assets:


### PR DESCRIPTION
It seems `context.sha` is available in the context of GitHub script. In
the action itself, however, it seems to be `github.sha`.