### PR TITLE
Use correct tag reference in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/create-gh-release-action@v1
         with:
-          ref: refs/tag/auto-${{ github.sha }}
+          ref: refs/tags/auto-${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-assets:


### PR DESCRIPTION
Git names tags with `refs/tags`, not `refs/tag`.