### PR TITLE
Only publish crate when source of manifest changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            - src: 'src/**'
+            - manifest: Cargo.toml
+
       - run: cargo publish --token ${CRATES_TOKEN}
+        if: |
+          {{ steps.changes.outputs.src == 'true' || steps.changes.outputs.manifest == 'true' }}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
This adds a step to the publish action that should prevent the action
from trying to publish the crate if no changes are made within `src` or
to `Cargo.toml`. I may want to extend this to `Cargo.lock`, but I'm
going to wait and see if Dependabot ever sends a pull request for just
that file. The motivation here was to allow me to make GitHub- and
linting-related changes without publish an unchanged crate.