### PR TITLE
Remove unnecessary braces from workflow definition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
             - manifest: Cargo.toml
 
       - run: cargo publish --token ${CRATES_TOKEN}
-        if: |
-          {{ steps.changes.outputs.src == 'true' || steps.changes.outputs.manifest == 'true' }}
+        if: steps.changes.outputs.src == 'true' || steps.changes.outputs.manifest == 'true'
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
When I updated the publish action in #67 I wasn't sure if YAML could
handle the `||` in the `if` section so I wrapped it in braces. Looks
like that broke the YAML so I'm trying it again without them.