### PR TITLE
Update the version number when publishing crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,31 @@ jobs:
             - src: 'src/**'
             - manifest: Cargo.toml
 
-      - run: cargo publish --token ${CRATES_TOKEN}
+      - name: Configure Git
+        run: |
+          git config user.email "github@github.com"
+          git config user.name "GitHub Actions"
+
+      - name: Set version number
+        run: |
+          count=$(git rev-list --count --branches --no-merges)
+          now=$(date +"%Y %m")
+          set $now
+          year=$1
+          month=$2
+          month="$((month+0))"
+          version="${year}.${month}.${count}"
+          echo $version
+          sed -i "s/^version = \"0.0.0\"/version = \"$version\"/" Cargo.toml
+          sed -i "s/^version = \"0.0.0\"/version = \"$version\"/" Cargo.lock
+          git stage -- Cargo.toml Cargo.lock
+          git commit -m"Release $version"
+
+      - name: Validate release
+        run: cargo package
+
+      - name: Publish crate
+        run: cargo publish --token ${CRATES_TOKEN}
         if: steps.changes.outputs.src == 'true' || steps.changes.outputs.manifest == 'true'
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "retro"
-version = "2024.2.1"
+version = "0.0.0"
 dependencies = [
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retro"
-version = "2024.2.1"
+version = "0.0.0"
 authors = ["Andy Dirnberger <andy.dirnberger@gmail.com>"]
 edition = "2021"
 description = "Retro game catalog management."


### PR DESCRIPTION
The publish action is being updated to include steps to set the version
number so that each release will be treated as a newer one. Calver will
still be used, with the current year and month being grabbed in the
action and the number of commits being used as the patch number. This
won't reset each month, but the whole thing is arbitrary and only exists
so that `cargo install` will see and install new releases.

As part of this change, the version number in `Cargo.toml` is being set
to `0.0.0`. This is being done to make it easier to identify it with
`sed`, but it also has the advantage that using a version from source
will have a different version number than a version installed by
`cargo`.

This approach is based on [a workflow I found on GitHub][workflow].

[workflow]: https://github.com/Emoun/duplicate/blob/1b504d3229aedcea1e34712d69d0e4f4e95e3ac0/.github/workflows/rust.yml#L74-L87