### PR TITLE
Fetch full history when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -41,7 +43,6 @@ jobs:
           month=$2
           month="$((month+0))"
           version="${year}.${month}.${count}"
-          echo $version
           sed -i "s/^version = \"0.0.0\"/version = \"$version\"/" Cargo.toml
           sed -i "s/^version = \"0.0.0\"/version = \"$version\"/" Cargo.lock
           git stage -- Cargo.toml Cargo.lock


### PR DESCRIPTION
By default, `actions/checkout` will only fetch a single revision. This
means that `git rev-list --count` will always return "1." In order to
get a proper count, the full history is needed. While setting the fetch
depth to "0" returns the history for all branches and tags, there
shouldn't be any of those to worry about.