### PR TITLE
Add version option to CLI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,7 @@ use super::rename;
 #[derive(Debug, Parser)]
 #[command(name = "retro")]
 #[command(about = "synchronize retro games")]
+#[command(version)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
This adds `--version` to the command line interface to check the version
number. It will be helpful to distinguish between an installed version
and one built from source.