### PR TITLE
Exit the publish workflow early

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,12 @@ jobs:
             - src: 'src/**'
             - manifest: Cargo.toml
 
+      - name: Check for releasable changes
+        if: steps.changes.outputs.src != 'true' && steps.changes.outputs.manifest != 'true'
+        run: |
+          echo "No changes were made to relevant files."
+          exit 1
+
       - name: Configure Git
         run: |
           git config user.email "github@github.com"
@@ -53,6 +59,5 @@ jobs:
 
       - name: Publish crate
         run: cargo publish --token ${CRATES_TOKEN}
-        if: steps.changes.outputs.src == 'true' || steps.changes.outputs.manifest == 'true'
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
Rather than doing a bunch of work and skipping only the `cargo publish`
step in the publish workflow, this will exit out of the workflow early
if no relevant changes were found. I've been having trouble with the
workflow not publishing the package when expected and I'm hoping that
exiting early instead of just skipping a step will help.