### PR TITLE
Adjust filtering in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,11 +26,13 @@ jobs:
         id: changes
         with:
           filters: |
-            - src: 'src/**'
-            - manifest: Cargo.toml
+            src:
+              - 'src/**'
+            manifest:
+              - 'Cargo.toml'
 
       - name: Check for releasable changes
-        if: steps.changes.outputs.src != 'true' && steps.changes.outputs.manifest != 'true'
+        if: steps.changes.outputs.src == 'false' && steps.changes.outputs.manifest == 'false'
         run: |
           echo "No changes were made to relevant files."
           exit 1


### PR DESCRIPTION
I'm still having trouble with the publish workflow. This both makes the
logic easier to read and updates the syntax used for defining the
filters. Looking at the [README] for `dorny/path-filters`, this seems to
be the correct way to write them.

[readme]: https://github.com/dorny/paths-filter/blob/ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a/README.md#example