### PR TITLE
Use default config but support override

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use std::env::var;
+use std::env::{var, VarError};
 use std::path::PathBuf;
 use std::process::{exit, Command};
 
@@ -11,16 +11,6 @@ pub fn capture_output<'a>(command: &'a mut Command, expected_message: &'a str) -
         Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
     };
     result.trim().to_string()
-}
-
-pub fn env_or_exit(name: &str) -> String {
-    match var(name) {
-        Ok(value) => value,
-        Err(error) => {
-            error!("{name:?}: {error}");
-            exit(1);
-        }
-    }
 }
 
 pub fn find_files(root: PathBuf, extensions: &[String]) -> Vec<PathBuf> {
@@ -37,6 +27,23 @@ pub fn find_files(root: PathBuf, extensions: &[String]) -> Vec<PathBuf> {
     }
 
     files_found
+}
+
+pub fn get_from_env(name: &str) -> Result<String, VarError> {
+    match var(name) {
+        Ok(value) => Ok(value),
+        Err(e) => Err(e),
+    }
+}
+
+pub fn get_from_env_or_exit(name: &str) -> String {
+    match var(name) {
+        Ok(value) => value,
+        Err(error) => {
+            error!("{name:?}: {error}");
+            exit(1);
+        }
+    }
 }
 
 // Adapted from https://users.rust-lang.org/t/is-this-code-idiomatic/51798/2.


### PR DESCRIPTION
Rather than requiring the `$RETRO_CONFIG` environment variable, this
will check for it and fall back to the default confy config file if it
isn't found. In order to support this, a new function, `get_from_env`,
is being added. Unlike `env_or_exit`, it will handle a missing
environment variable gracefully. `env_from_exit` is being renamed to
`get_from_env_or_exit` to keep the two functions consistent.

With this change, there is increased potential for the app to run with
an empty config and not do much, at least in terms of linking games. Not
only do I need to document the structure of the config, but I should
also consider exposing a way to modify it through the app itself.