### PR TITLE
Support compress-specific config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::env::current_dir;
+use std::path::{Path, PathBuf};
 
 use super::utils::{get_from_env, get_from_env_or_exit};
 
@@ -133,6 +134,28 @@ pub fn load_config() -> Result<Config, String> {
     };
 
     Ok(config)
+}
+
+pub fn load_config_recursively<T: serde::Serialize + serde::de::DeserializeOwned + Default>(
+    root: &Path,
+) -> Result<T, String> {
+    let mut path: PathBuf = root.into();
+    if path == PathBuf::from(".") {
+        path = current_dir().unwrap();
+    }
+    let file = Path::new("retro.toml");
+
+    loop {
+        path.push(file);
+
+        if path.is_file() {
+            break Ok(confy::load_path(path).unwrap());
+        }
+
+        if !(path.pop() && path.pop()) {
+            break Err("No retro.toml file found".to_string());
+        }
+    }
 }
 
 pub fn load_link_destination_config(


### PR DESCRIPTION
This introduces a special config for the compress command. In a
departure from how the config for the link command works, this structure
of this config is defined as part of the `compress` module. A new
function, `load_config_recursively`, is being added to find a
`retro.toml` file in a directory or one of its ancestors.

Unlike `load_config` and `load_link_destination_config`,
`load_config_recursively` returns a generic type; the caller must
specify the type. I'd like to adapt this for the link command's config
as well, but I might run into limitations with the presence of a config
used by another command. If that doesn't go well, I may need to rethink
the approach here.