### PR TITLE
Move logic for finding a file recursively to utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +294,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "retro"
 version = "0.0.0"
 dependencies = [
@@ -347,6 +399,7 @@ dependencies = [
  "log",
  "regex",
  "serde",
+ "tempdir",
 ]
 
 [[package]]
@@ -393,6 +446,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -466,6 +529,28 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ env_logger = "0.11.1"
 log = "0.4.20"
 regex = "1.10.3"
 serde = { version = "1.0.197", features = ["derive"] }
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
-use std::env::current_dir;
 use std::path::{Path, PathBuf};
 
-use super::utils::{get_from_env, get_from_env_or_exit};
+use super::utils::{find_file_recursively, get_from_env, get_from_env_or_exit};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct Config {
@@ -139,22 +138,9 @@ pub fn load_config() -> Result<Config, String> {
 pub fn load_config_recursively<T: serde::Serialize + serde::de::DeserializeOwned + Default>(
     root: &Path,
 ) -> Result<T, String> {
-    let mut path: PathBuf = root.into();
-    if path == PathBuf::from(".") {
-        path = current_dir().unwrap();
-    }
-    let file = Path::new("retro.toml");
-
-    loop {
-        path.push(file);
-
-        if path.is_file() {
-            break Ok(confy::load_path(path).unwrap());
-        }
-
-        if !(path.pop() && path.pop()) {
-            break Err("No retro.toml file found".to_string());
-        }
+    match find_file_recursively(root, "retro.toml") {
+        Some(path) => Ok(confy::load_path(path).unwrap()),
+        None => Err("No retro.toml file found".to_string()),
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
-use std::env::{var, VarError};
-use std::path::PathBuf;
+use std::env::{current_dir, var, VarError};
+use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 
 use log::error;
@@ -27,6 +27,26 @@ pub fn find_files(root: PathBuf, extensions: &[String]) -> Vec<PathBuf> {
     }
 
     files_found
+}
+
+pub fn find_file_recursively(root: &Path, name: &str) -> Option<PathBuf> {
+    let mut path: PathBuf = root.into();
+    if path == PathBuf::from(".") {
+        path = current_dir().unwrap();
+    }
+    let file = Path::new(name);
+
+    loop {
+        path.push(file);
+
+        if path.is_file() {
+            break Some(path);
+        }
+
+        if !(path.pop() && path.pop()) {
+            break None;
+        }
+    }
 }
 
 pub fn get_from_env(name: &str) -> Result<String, VarError> {
@@ -65,62 +85,6 @@ pub fn longest_common_prefix(vals: &[String]) -> &str {
     common
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_longest_common_prefix_with_no_strings() {
-        assert_eq!(longest_common_prefix(&[]), "");
-    }
-
-    #[test]
-    fn test_longest_common_prefix_with_one_string() {
-        assert_eq!(longest_common_prefix(&["abc".to_string()]), "abc");
-    }
-
-    #[test]
-    fn test_longest_common_prefix_with_one_string_twice() {
-        assert_eq!(
-            longest_common_prefix(&["abc".to_string(), "abc".to_string()]),
-            "abc"
-        );
-    }
-
-    #[test]
-    fn test_longest_common_prefix_with_one_string_that_is_a_substring_of_the_other() {
-        assert_eq!(
-            longest_common_prefix(&["abc".to_string(), "abcdef".to_string()]),
-            "abc"
-        );
-        assert_eq!(
-            longest_common_prefix(&["abcdef".to_string(), "abc".to_string()]),
-            "abc"
-        );
-    }
-
-    #[test]
-    fn test_longest_common_prefix_with_no_common_prefix() {
-        assert_eq!(
-            longest_common_prefix(&["abc".to_string(), "def".to_string()]),
-            ""
-        );
-    }
-
-    #[test]
-    fn test_longest_common_prefix_with_some_strings() {
-        assert_eq!(
-            longest_common_prefix(&[
-                "abcdef".to_string(),
-                "abcdeg".to_string(),
-                "abcdhi".to_string(),
-                "abcjkl".to_string(),
-            ]),
-            "abc"
-        );
-    }
-}
-
 pub fn require_command(command: &str) -> Command {
     if let Ok(output) = Command::new("which").arg(command).output() {
         if output.status.success() {
@@ -136,5 +100,117 @@ pub fn stream_output(command: &mut Command, expected_message: &str) {
     let exit_status = child.wait().expect(expected_message);
     if !exit_status.success() {
         exit(exit_status.code().unwrap());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::{create_dir, File};
+
+    use tempdir::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn find_file_recursively_does_not_find_file_in_child() {
+        let tmp_dir = TempDir::new("retro").unwrap();
+        let _ = create_dir(tmp_dir.path().join("child")).unwrap();
+        let file_path = tmp_dir.path().join("child").join("test");
+        let _ = File::create(&file_path).unwrap();
+
+        let result = find_file_recursively(tmp_dir.path(), "test");
+        assert_eq!(None, result);
+
+        tmp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn find_file_recursively_finds_file_in_grandparent() {
+        let tmp_dir = TempDir::new("retro").unwrap();
+        let file_path = tmp_dir.path().join("test");
+        let _ = File::create(&file_path).unwrap();
+        let grandchild_path = tmp_dir.path().join("child").join("grandchild");
+
+        let result = find_file_recursively(&grandchild_path, "test");
+        assert_eq!(file_path, result.unwrap());
+
+        tmp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn find_file_recursively_finds_file_in_parent() {
+        let tmp_dir = TempDir::new("retro").unwrap();
+        let file_path = tmp_dir.path().join("test");
+        let _ = File::create(&file_path).unwrap();
+        let child_path = tmp_dir.path().join("child");
+
+        let result = find_file_recursively(&child_path, "test");
+        assert_eq!(file_path, result.unwrap());
+
+        tmp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn find_file_recursively_finds_file_in_root() {
+        let tmp_dir = TempDir::new("retro").unwrap();
+        let file_path = tmp_dir.path().join("test");
+        let _ = File::create(&file_path).unwrap();
+
+        let result = find_file_recursively(tmp_dir.path(), "test");
+        assert_eq!(file_path, result.unwrap());
+
+        tmp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn longest_common_prefix_returns_no_prefix_with_no_strings() {
+        assert_eq!(longest_common_prefix(&[]), "");
+    }
+
+    #[test]
+    fn longest_common_prefix_returns_full_string_with_one_string() {
+        assert_eq!(longest_common_prefix(&["abc".to_string()]), "abc");
+    }
+
+    #[test]
+    fn longest_common_prefix_returns_full_string_with_one_string_twice() {
+        assert_eq!(
+            longest_common_prefix(&["abc".to_string(), "abc".to_string()]),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn longest_common_prefix_returns_shorter_string_with_one_string_that_is_a_substring_of_the_other(
+    ) {
+        assert_eq!(
+            longest_common_prefix(&["abc".to_string(), "abcdef".to_string()]),
+            "abc"
+        );
+        assert_eq!(
+            longest_common_prefix(&["abcdef".to_string(), "abc".to_string()]),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn longest_common_prefix_returns_no_prefix_with_no_common_prefix() {
+        assert_eq!(
+            longest_common_prefix(&["abc".to_string(), "def".to_string()]),
+            ""
+        );
+    }
+
+    #[test]
+    fn longest_common_prefix_returns_prefix_with_some_strings() {
+        assert_eq!(
+            longest_common_prefix(&[
+                "abcdef".to_string(),
+                "abcdeg".to_string(),
+                "abcdhi".to_string(),
+                "abcjkl".to_string(),
+            ]),
+            "abc"
+        );
     }
 }


### PR DESCRIPTION
The code that finds a file recursively may have uses outside of just
loading a config so I decided to move it out of
`load_config_recursively` and create a new function,
`find_file_recursively`. This has the added benefit of making the logic
easier to test.

While adding the tests I noticed that the `utils` module's tests were in
the middle of the file. They are being moved to the end. When running
the tests, I noticed that the naming was different between the `config`
and `utils` modules, so the latter's tests are being renamed to match.