### PR TITLE
Treat skipped workflows as successful

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         if: contains(github.event.head_commit.message, '[skip publish]')
         run: |
           echo "[skip publish] found."
-          exit 1
+          exit 0
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -47,7 +47,7 @@ jobs:
         if: steps.changes.outputs.src == 'false' && steps.changes.outputs.manifest == 'false'
         run: |
           echo "No changes were made to relevant files."
-          exit 1
+          exit 0
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
When I added logic to the publish workflow to skip it, I decided to have
it return a non-zero exit code. While I like seeing that the job don't
run completely, seeing that it failed is a bit misleading. Plus it can
cause me to miss an actual failure with the job.