### PR TITLE
Revert "Merge pull request #82 from dirn/skip-is-success"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         if: contains(github.event.head_commit.message, '[skip publish]')
         run: |
           echo "[skip publish] found."
-          exit 0
+          exit 1
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -47,7 +47,7 @@ jobs:
         if: steps.changes.outputs.src == 'false' && steps.changes.outputs.manifest == 'false'
         run: |
           echo "No changes were made to relevant files."
-          exit 0
+          exit 1
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
It turns out `exit 0` doesn't exit the workflow, it just treats the step
as complete. This caused the publish workflow to publish the crate even
when it shouldn't.

This reverts commit d3d3f9a4bd93bf80966c5051bbc95a5806e0492a, reversing
changes made to e035d9dd780d9b05b0a43afa25702a80a83e81fc.