### PR TITLE
Rename load_config to load_global_config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,7 +121,16 @@ impl System {
     }
 }
 
-pub fn load_config() -> Result<Config, String> {
+pub fn load_config_recursively<T: serde::Serialize + serde::de::DeserializeOwned + Default>(
+    root: &Path,
+) -> Result<T, String> {
+    match find_file_recursively(root, "retro.toml") {
+        Some(path) => Ok(confy::load_path(path).unwrap()),
+        None => Err("No retro.toml file found".to_string()),
+    }
+}
+
+pub fn load_global_config() -> Result<Config, String> {
     let config: Config = match get_from_env("RETRO_CONFIG") {
         Ok(path) => confy::load_path(PathBuf::from(path)).unwrap(),
         Err(_) => match confy::load("retro", "retro") {
@@ -133,15 +142,6 @@ pub fn load_config() -> Result<Config, String> {
     };
 
     Ok(config)
-}
-
-pub fn load_config_recursively<T: serde::Serialize + serde::de::DeserializeOwned + Default>(
-    root: &Path,
-) -> Result<T, String> {
-    match find_file_recursively(root, "retro.toml") {
-        Some(path) => Ok(confy::load_path(path).unwrap()),
-        None => Err("No retro.toml file found".to_string()),
-    }
 }
 
 pub fn load_link_destination_config(

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,6 +1,6 @@
 use log::{error, info};
 
-use super::config::load_config;
+use super::config::load_global_config;
 use super::games;
 
 #[derive(Debug, clap::Args)]
@@ -38,7 +38,7 @@ pub fn dispatch(args: Args) -> Result<(), String> {
 }
 
 fn link(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
-    let config = match load_config() {
+    let config = match load_global_config() {
         Ok(config) => config.link,
         Err(e) => {
             return Err(e);


### PR DESCRIPTION
There is a bit of a mismatch between the purpose of `load_config` and
`load_config_recursively`. The latter will look for a config file in the
specified location (or its ancestors); the former loads the
application-wide, a.k.a. global, config. The former is being renamed to
show this difference. It opens the door to adding a `load_config` later
on that works like `load_config_recursively` but without checking
ancestors.