### PR TITLE
Add a dispatch trait to commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,9 +41,9 @@ pub fn dispatch() -> Result<(), String> {
         .init();
 
     match args.command {
-        Commands::Compress(args) => compress::dispatch(args),
-        Commands::Link(args) => link::dispatch(args),
-        Commands::Playlist(args) => playlist::dispatch(args),
-        Commands::Rename(args) => rename::dispatch(args),
+        Commands::Compress(args) => args.dispatch(),
+        Commands::Link(args) => args.dispatch(),
+        Commands::Playlist(args) => args.dispatch(),
+        Commands::Rename(args) => args.dispatch(),
     }
 }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -37,11 +37,13 @@ struct ChdArgs {
     force: bool,
 }
 
-pub fn dispatch(args: Args) -> Result<(), String> {
-    let cmd = args.command.unwrap_or(Commands::Chd(args.chd));
-    match cmd {
-        Commands::Chd(args) => {
-            compress_to_chd(args.source, args.dest.clone(), args.dvd, args.force)
+impl Args {
+    pub fn dispatch(self) -> Result<(), String> {
+        let cmd = self.command.unwrap_or(Commands::Chd(self.chd));
+        match cmd {
+            Commands::Chd(args) => {
+                compress_to_chd(args.source, args.dest.clone(), args.dvd, args.force)
+            }
         }
     }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -30,10 +30,12 @@ struct LinkArgs {
     all: bool,
 }
 
-pub fn dispatch(args: Args) -> Result<(), String> {
-    let cmd = args.command.unwrap_or(Commands::Link(args.link));
-    match cmd {
-        Commands::Link(args) => link(args.system, args.all),
+impl Args {
+    pub fn dispatch(self) -> Result<(), String> {
+        let cmd = self.command.unwrap_or(Commands::Link(self.link));
+        match cmd {
+            Commands::Link(args) => link(args.system, args.all),
+        }
     }
 }
 

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -32,10 +32,12 @@ struct GenerateArgs {
     source: PathBuf,
 }
 
-pub fn dispatch(args: Args) -> Result<(), String> {
-    let cmd = args.command.unwrap_or(Commands::Generate(args.generate));
-    match cmd {
-        Commands::Generate(args) => generate_m3u_playlists(args.source),
+impl Args {
+    pub fn dispatch(self) -> Result<(), String> {
+        let cmd = self.command.unwrap_or(Commands::Generate(self.generate));
+        match cmd {
+            Commands::Generate(args) => generate_m3u_playlists(args.source),
+        }
     }
 }
 

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -32,10 +32,12 @@ struct BinCueArgs {
     new: Option<String>,
 }
 
-pub fn dispatch(args: Args) -> Result<(), String> {
-    let cmd = args.command.unwrap_or(Commands::BinCue(args.bin_cue));
-    match cmd {
-        Commands::BinCue(args) => rename_bin_cue_files(args.source, args.new),
+impl Args {
+    pub fn dispatch(self) -> Result<(), String> {
+        let cmd = self.command.unwrap_or(Commands::BinCue(self.bin_cue));
+        match cmd {
+            Commands::BinCue(args) => rename_bin_cue_files(args.source, args.new),
+        }
     }
 }
 


### PR DESCRIPTION
This introduces an unbound trait that adds a `dispatch` method to
commands. While this increases the boilerplate needed when defining a
command, it reduces some of it when dispatching to them.

I'd love to simplify things inside `cli.rs` even more, but since each
command's arguments are of a different type, I'll probably need a macro
that generates the match branches for me accomplish that.
