### PR TITLE
Add clean subcommand to remove broken links

### DIFF
--- a/src/games.rs
+++ b/src/games.rs
@@ -1,5 +1,5 @@
 use std::env::set_current_dir;
-use std::fs::{canonicalize, symlink_metadata};
+use std::fs::{canonicalize, remove_file, symlink_metadata};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -7,6 +7,74 @@ use log::{debug, info, warn};
 
 use super::config::load_link_destination_config;
 use super::utils::{capture_output, find_files};
+
+pub fn clean(
+    destination: &PathBuf,
+    systems: &[String],
+    all_systems: bool,
+    dry_run: bool,
+) -> Result<(), String> {
+    let changed = set_current_dir(Path::new(&destination));
+    if changed.is_err() {
+        return Err(format!("{:#?}", changed.err()));
+    }
+
+    let config = match load_link_destination_config(None) {
+        Ok(config) => config,
+        Err(e) => {
+            return Err(e);
+        }
+    };
+
+    let configured_systems = config.get_system_names();
+    let systems_to_clean = if all_systems {
+        &configured_systems
+    } else {
+        systems
+    };
+
+    for system in systems_to_clean {
+        let system_config = match config.systems.get(system) {
+            Some(config) => config,
+            None => {
+                warn!("{system} not found in config. Skipping.");
+                continue;
+            }
+        };
+
+        let extensions = system_config.get_extensions(system);
+
+        let destinations = system_config.get_destinations(system);
+        for clean_destination in destinations {
+            let mut path = destination.join(clean_destination);
+            if let Some(extra_path) = &system_config.extra_path {
+                path = path.join(extra_path);
+            }
+            let _ = set_current_dir(&path).is_ok();
+            debug!("Checking for broken {extensions:?} links in {path:?}.");
+
+            let files_to_clean = find_files(path.clone(), &extensions);
+
+            for file in &files_to_clean {
+                let metadata = symlink_metadata(&file).unwrap();
+                if metadata.is_symlink() {
+                    if let Err(_) = canonicalize(&file) {
+                        if dry_run {
+                            warn!("Broken symlink found at {file:?}. Skipping.");
+                        } else {
+                            if let Err(e) = remove_file(file) {
+                                warn!("{e}");
+                            };
+                        }
+                        info!("{file:?} unlinked");
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
 
 pub fn link(
     source: &PathBuf,


### PR DESCRIPTION
Sometimes I move files around or rename them and end up with broken
symlinks. This adds a clean subcommand that will look for such links and
remove them. The subcommand accepts a flag to tell it whether or not to
perform a dry run instead of actually removing the files.
