### PR TITLE
Strip leading zero from month in version number

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           set $now
           year=$1
           month=$2
-          month="$((month+0))"
+          let "month=10#${month}"
           version="${year}.${month}.${count}"
           sed -i "s/^version = \"0.0.0\"/version = \"$version\"/" Cargo.toml
           sed -i "s/^version = \"0.0.0\"/version = \"$version\"/" Cargo.lock


### PR DESCRIPTION
When getting the currently month, single digit values are prefixed with
a zero. I _thought_ `$((month+0))` was stripping the zero. It turns out,
however, that Cargo treats the value as a number, not a string, so it
was ignoring the zero.

`08` is treated as an octal value rather than as a decimal one. So once
August rolled around, the publish workflow began to fail because of

```
invalid leading zero in minor version number
```

This updates the approach to stripping the leading zero. Since there is
no way to test the workflow (and manually testing the old approach
worked), hopefully this works.

Reference: https://stackoverflow.com/a/62757839
