### PR TITLE
Adjust logging levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ command takes an action (e.g., a symlink is created). This includes dry runs of
 commands. They should also be used to report actual errors.
 
 `warn` logs should be used when an action is skipped (e.g., a symlink already
-exists).
+exists). They should also be used to report a summary of output that is normally
+streamed from an underlying command.
 
 `info` logs should be used to indicate that no action was attempted (e.g., a
 system is not configured).

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use log::{debug, info, log_enabled, warn, Level};
+use log::{debug, log_enabled, warn, Level};
 
 use super::config::load_config_recursively;
 use super::utils::{capture_output, find_files, require_command, stream_output};
@@ -88,7 +88,7 @@ fn compress_to_chd(
     let config: CompressConfig = match load_config_recursively(&source) {
         Ok(config) => config,
         Err(_) => {
-            warn!("No custom config found, using default compression settings");
+            debug!("No custom config found, using default compression settings");
             Config::default()
         }
     }
@@ -105,7 +105,7 @@ fn compress_to_chd(
         let mut output_file = output_path.join(file.file_name().unwrap());
         output_file.set_extension("chd");
         if !force && output_file.exists() {
-            info!("{} exists. Skipping.", output_file.display());
+            warn!("{} exists. Skipping.", output_file.display());
             continue;
         }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,4 +1,4 @@
-use log::{error, info};
+use log::{debug, error};
 
 use super::config::load_global_config;
 use super::games;
@@ -66,11 +66,8 @@ fn clean_links(systems: Vec<String>, all_systems: bool, dry_run: bool) -> Result
     };
 
     for destination in config.expand_destinations() {
-        match games::clean(&destination, &systems, all_systems, dry_run) {
-            Ok(_) => info!(""),
-            Err(e) => {
-                error!("{e:#?}");
-            }
+        if let Err(e) = games::clean(&destination, &systems, all_systems, dry_run) {
+            error!("{e:#?}");
         }
     }
 
@@ -86,16 +83,11 @@ fn link(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
     };
 
     for destination in config.expand_destinations() {
-        match games::link(&config.expand_source(), &destination, &systems, all_systems) {
-            Ok(_) => info!(""),
-            Err(e) => {
-                error!("{e:#?}");
-            }
+        debug!("Linking games to {destination:?}");
+        if let Err(e) = games::link(&config.expand_source(), &destination, &systems, all_systems) {
+            error!("{e:#?}");
         }
     }
-
-    // This isn't really an error but I currently want it to appear unless output is suppressed.
-    error!("Done.");
 
     Ok(())
 }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
-use log::{debug, error, info};
+use log::{debug, error};
 
 use regex::Regex;
 
@@ -67,7 +67,7 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
             continue;
         }
 
-        info!("Generating {playlist_file:?}");
+        error!("Generating {playlist_file:?}");
 
         let mut f = File::create(playlist_file.clone()).expect("Unable to create playlist");
         for file in files {


### PR DESCRIPTION
This brings most of the logging in line with the guidelines established
in the README. I'm also removing the logging calls that are used just to
control the output.

Closes #119
