### PR TITLE
Break up find_files

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use log::{debug, log_enabled, warn, Level};
 
 use super::config::load_config_recursively;
-use super::utils::{capture_output, find_files, require_command, stream_output};
+use super::utils::{capture_output, find_files_with_extension, require_command, stream_output};
 
 #[derive(Debug, clap::Args)]
 #[command(about = "Compress games")]
@@ -94,7 +94,7 @@ fn compress_to_chd(
     }
     .compress;
 
-    let files_to_compress = find_files(source, &config.extensions);
+    let files_to_compress = find_files_with_extension(&source, &config.extensions);
 
     let mut image_format: &str = &format!("create{}", config.format);
     if as_dvd {

--- a/src/games.rs
+++ b/src/games.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use log::{debug, error, info, warn};
 
 use super::config::load_link_destination_config;
-use super::utils::{capture_output, find_files};
+use super::utils::{capture_output, find_files_with_extension};
 
 pub fn clean(
     destination: &PathBuf,
@@ -53,7 +53,7 @@ pub fn clean(
             let _ = set_current_dir(&path).is_ok();
             debug!("Checking for broken {extensions:?} links in {path:?}.");
 
-            let files_to_clean = find_files(path.clone(), &extensions);
+            let files_to_clean = find_files_with_extension(&path, &extensions);
 
             for file in &files_to_clean {
                 let metadata = symlink_metadata(&file).unwrap();
@@ -119,7 +119,7 @@ pub fn link(
 
         let extensions = system_config.get_extensions(system);
 
-        let files_to_link = find_files(system_source.clone(), &extensions);
+        let files_to_link = find_files_with_extension(&system_source, &extensions);
 
         let destinations = system_config.get_destinations(system);
         for link_destination in destinations {

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -7,7 +7,7 @@ use log::{debug, error};
 
 use regex::Regex;
 
-use super::utils::find_files;
+use super::utils::find_files_with_extension;
 
 #[derive(Debug, clap::Args)]
 #[command(about = "Create playlist files for multidisc games")]
@@ -48,7 +48,7 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
 
     let mut matches: HashMap<String, Vec<String>> = HashMap::new();
 
-    for file in find_files(source.clone(), &["chd".to_string()]) {
+    for file in find_files_with_extension(&source, &["chd".to_string()]) {
         let file_name = file.file_name().unwrap().to_str().unwrap();
         let capture = re.captures(file_name);
         if let Some(capture) = capture {

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use log::{debug, error};
 
-use super::utils::{find_files, longest_common_prefix};
+use super::utils::{find_files_with_extension, longest_common_prefix};
 
 #[derive(Debug, clap::Args)]
 #[command(about = "Rename files")]
@@ -52,7 +52,7 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     debug!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
 
     let mut file_names = Vec::new();
-    for file in find_files(source.clone(), &["bin".to_string(), "cue".to_string()]) {
+    for file in find_files_with_extension(&source, &["bin".to_string(), "cue".to_string()]) {
         if let Some(file_name) = file.file_name() {
             file_names.push(file_name.to_str().unwrap().to_string());
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,14 +13,29 @@ pub fn capture_output<'a>(command: &'a mut Command, expected_message: &'a str) -
     result.trim().to_string()
 }
 
-pub fn find_files(root: PathBuf, extensions: &[String]) -> Vec<PathBuf> {
+pub fn find_files(root: &Path) -> Vec<PathBuf> {
     let mut files_found = Vec::new();
-    for file in root.read_dir().unwrap() {
-        let path = file.unwrap().path();
-        if let Some(extension) = path.extension() {
+    for entry in root.read_dir().unwrap() {
+        if let Ok(entry) = entry {
+            let path = entry.path();
+            if path.is_dir() {
+                files_found.append(&mut find_files(&path));
+            } else {
+                files_found.push(path);
+            }
+        }
+    }
+
+    files_found
+}
+
+pub fn find_files_with_extension(root: &Path, extensions: &[String]) -> Vec<PathBuf> {
+    let mut files_found = Vec::new();
+    for file in find_files(&root) {
+        if let Some(extension) = file.extension() {
             if let Some(extension) = extension.to_str() {
                 if extensions.contains(&extension.to_string()) {
-                    files_found.push(path);
+                    files_found.push(file);
                 }
             }
         }


### PR DESCRIPTION
`find_files` is designed to find files in a directory that match one or
more extensions. This functionality is useful. It will continue to live
on as `find_files_with_extension`. The inner logic to find all files --
what drives the extension filter -- is being split into a separate
function. It will receive the freed up `find_files` name.

This function isn't immediately useful but it will become valuable as I
make some changes to the config logic.
