### PR TITLE
Use default value for matched bin names

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -56,7 +56,7 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
             let after = capture.name("after").unwrap().as_str().to_string();
             matches
                 .entry(format!("{before}{after}"))
-                .or_insert_with(|| vec![])
+                .or_default()
                 .push(capture.get(0).unwrap().as_str().to_string())
         }
     }


### PR DESCRIPTION
This should have no material difference, but the intent of `or_default`
is much clearer, at least to me, than `or_insert_with(|| vec![])`.
