### PR TITLE
Add initial code to parse dat files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "f29222b549d4e3ded127989d523da9e928918d0d0d7f7c1690b439d0d538bae9"
 dependencies = [
  "directories",
  "serde",
- "thiserror",
+ "thiserror 2.0.12",
  "toml",
 ]
 
@@ -438,7 +438,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -490,6 +490,7 @@ dependencies = [
  "log",
  "regex",
  "serde",
+ "serde-xml-rs",
  "tempdir",
  "test-context",
 ]
@@ -501,6 +502,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53630160a98edebde0123eb4dfd0fce6adff091b2305db3154a9e920206eb510"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 1.0.69",
+ "xml-rs",
 ]
 
 [[package]]
@@ -582,11 +595,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -821,3 +854,9 @@ checksum = "7a4191c47f15cc3ec71fcb4913cb83d58def65dd3787610213c649283b5ce178"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.11.6"
 log = "0.4.27"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
+serde-xml-rs = "0.8.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/dat.rs
+++ b/src/dat.rs
@@ -1,0 +1,133 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+// Initially generated using https://thomblin.github.io/xml_schema_generator/.
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct Datafile {
+    pub header: Header,
+    pub game: Vec<Game>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct Header {
+    pub id: u32,
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct Game {
+    #[serde(rename = "@name")]
+    pub name: String,
+    #[serde(rename = "@id")]
+    pub id: String,
+    pub rom: Rom,
+}
+
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct Rom {
+    #[serde(rename = "@name")]
+    pub name: String,
+    #[serde(rename = "@size")]
+    pub size: u32,
+    #[serde(rename = "@crc")]
+    pub crc: String,
+    #[serde(rename = "@md5")]
+    pub md5: String,
+    #[serde(rename = "@sha1")]
+    pub sha1: String,
+    #[serde(rename = "@sha256")]
+    pub sha256: String,
+    #[serde(rename = "@status")]
+    pub status: Option<String>,
+}
+
+pub fn load_from_string(xml: String) -> Datafile {
+    let dat: Datafile = serde_xml_rs::from_str(&xml).unwrap();
+    dat
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_game() {
+        let xml = r#"<?xml version="1.0"?>
+            <datafile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://datomatic.no-intro.org/stuff https://datomatic.no-intro.org/stuff/schema_nointro_datfile_v3.xsd">
+                <header>
+                    <id>1</id>
+                    <name>Test System</name>
+                    <version>000000</version>
+                </header>
+                <game name="Test Game" id="0001">
+                    <rom name="Test Game.ext" size="40976" crc="393a432f" md5="f94bb9bb55f325d9af8a0fff80b9376d" sha1="33d23c2f2cfa4c9efec87f7bc1321ce3ce6c89bd" sha256="0b3d9e1f01ed1668205bab34d6c82b0e281456e137352e4f36a9b2cfa3b66dea" status="verified" header="4E 45 53 1A 02 01 01 08 00 00 00 00 02 00 00 01"/>
+                </game>
+            </datafile>
+            "#;
+
+        let dat = load_from_string(xml.to_string());
+        assert_eq!(dat.header.id, 1);
+        assert_eq!(dat.header.name, "Test System");
+        assert_eq!(dat.header.version, "000000");
+
+        assert_eq!(dat.game.len(), 1);
+
+        let game = &dat.game[0];
+        assert_eq!(game.name, "Test Game");
+        assert_eq!(game.id, "0001");
+        assert_eq!(game.rom.name, "Test Game.ext");
+        assert_eq!(game.rom.size, 40976);
+        assert_eq!(game.rom.crc, "393a432f");
+        assert_eq!(game.rom.md5, "f94bb9bb55f325d9af8a0fff80b9376d");
+        assert_eq!(game.rom.sha1, "33d23c2f2cfa4c9efec87f7bc1321ce3ce6c89bd");
+        assert_eq!(
+            game.rom.sha256,
+            "0b3d9e1f01ed1668205bab34d6c82b0e281456e137352e4f36a9b2cfa3b66dea"
+        );
+    }
+
+    #[test]
+    fn parse_two_games() {
+        let xml = r#"<?xml version="1.0"?>
+            <datafile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://datomatic.no-intro.org/stuff https://datomatic.no-intro.org/stuff/schema_nointro_datfile_v3.xsd">
+                <header>
+                    <id>1</id>
+                    <name>Test System</name>
+                    <version>000000</version>
+                </header>
+                <game name="Test Game" id="0001">
+                    <rom name="Test Game.ext" size="40976" crc="393a432f" md5="f94bb9bb55f325d9af8a0fff80b9376d" sha1="33d23c2f2cfa4c9efec87f7bc1321ce3ce6c89bd" sha256="0b3d9e1f01ed1668205bab34d6c82b0e281456e137352e4f36a9b2cfa3b66dea" status="verified" header="4E 45 53 1A 02 01 01 08 00 00 00 00 02 00 00 01"/>
+                </game>
+                <game name="Test Game 2" id="0002">
+                    <rom name="Test Game 2.ext" size="262160" crc="43507232" md5="55f7030dc6173f2a0145a97f369f49f4" sha1="d3f8cfd7822c1cf634c2132009f877b44244850f" sha256="41300bc4942a8a4f9b53148b404dd5cae3dd708ebdd9b617888d290a51a83e43" status="verified" header="4E 45 53 1A 08 10 40 08 00 00 07 00 00 00 00 01"/>
+                </game>
+            </datafile>
+            "#;
+
+        let dat = load_from_string(xml.to_string());
+        assert_eq!(dat.header.id, 1);
+        assert_eq!(dat.header.name, "Test System");
+        assert_eq!(dat.header.version, "000000");
+
+        assert_eq!(dat.game.len(), 2);
+
+        let game1 = &dat.game[0];
+        assert_eq!(game1.name, "Test Game");
+        assert_eq!(game1.rom.name, "Test Game.ext");
+
+        let game2 = &dat.game[1];
+        assert_eq!(game2.name, "Test Game 2");
+        assert_eq!(game2.id, "0002");
+        assert_eq!(game2.rom.name, "Test Game 2.ext");
+        assert_eq!(game2.rom.size, 262160);
+        assert_eq!(game2.rom.crc, "43507232");
+        assert_eq!(game2.rom.md5, "55f7030dc6173f2a0145a97f369f49f4");
+        assert_eq!(game2.rom.sha1, "d3f8cfd7822c1cf634c2132009f877b44244850f");
+        assert_eq!(
+            game2.rom.sha256,
+            "41300bc4942a8a4f9b53148b404dd5cae3dd708ebdd9b617888d290a51a83e43"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod compress;
 mod config;
+mod dat;
 mod games;
 mod link;
 mod playlist;


### PR DESCRIPTION
I'd like to be able to organize my games. I'd like to use the names
established by databases such as No-Intro and Redump. This is the first
step in getting there. This adds a module that can parse the dat files
provided by these databases. The structures used for the data is
currently based on a file from No-Intro. I suspect it will need to be
modified when tested with a file from Redump (e.g., multiple files for a
game).
