### PR TITLE
Replace panics with proper error handling

### DIFF
--- a/src/dat.rs
+++ b/src/dat.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use serde::{Deserialize, Serialize};
 
 // Initially generated using https://thomblin.github.io/xml_schema_generator/.
@@ -43,9 +41,8 @@ pub struct Rom {
     pub status: Option<String>,
 }
 
-pub fn load_from_string(xml: String) -> Datafile {
-    let dat: Datafile = serde_xml_rs::from_str(&xml).unwrap();
-    dat
+pub fn load_from_string(xml: String) -> Result<Datafile, String> {
+    serde_xml_rs::from_str(&xml).map_err(|e| format!("Failed to parse XML dat file: {}", e))
 }
 
 #[cfg(test)]
@@ -67,7 +64,7 @@ mod tests {
             </datafile>
             "#;
 
-        let dat = load_from_string(xml.to_string());
+        let dat = load_from_string(xml.to_string()).unwrap();
         assert_eq!(dat.header.id, 1);
         assert_eq!(dat.header.name, "Test System");
         assert_eq!(dat.header.version, "000000");
@@ -106,7 +103,7 @@ mod tests {
             </datafile>
             "#;
 
-        let dat = load_from_string(xml.to_string());
+        let dat = load_from_string(xml.to_string()).unwrap();
         assert_eq!(dat.header.id, 1);
         assert_eq!(dat.header.name, "Test System");
         assert_eq!(dat.header.version, "000000");

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -44,20 +44,35 @@ impl Args {
 fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
     debug!("Generating playlists for files in {source:?}");
 
-    let re = Regex::new(r"(?<before>.+) \(Disc (?<disc>\d+)\)(?<after>.*)\.[^.]+$").unwrap();
+    let re = Regex::new(r"(?<before>.+) \(Disc (?<disc>\d+)\)(?<after>.*)\.[^.]+$")
+        .map_err(|e| format!("Failed to compile regex: {}", e))?;
 
     let mut matches: HashMap<String, Vec<String>> = HashMap::new();
 
-    for file in find_files_with_extension(&source, &["chd".to_string()]) {
-        let file_name = file.file_name().unwrap().to_str().unwrap();
+    for file in find_files_with_extension(&source, &["chd".to_string()])? {
+        let file_name = file
+            .file_name()
+            .ok_or_else(|| format!("File {} has no filename", file.display()))?
+            .to_str()
+            .ok_or_else(|| format!("File name {} is not valid UTF-8", file.display()))?;
         let capture = re.captures(file_name);
         if let Some(capture) = capture {
-            let before = capture.name("before").unwrap().as_str().to_string();
-            let after = capture.name("after").unwrap().as_str().to_string();
+            let before = capture
+                .name("before")
+                .ok_or_else(|| format!("Regex capture 'before' not found for {}", file_name))?
+                .as_str();
+            let after = capture
+                .name("after")
+                .ok_or_else(|| format!("Regex capture 'after' not found for {}", file_name))?
+                .as_str();
+            let full_match = capture
+                .get(0)
+                .ok_or_else(|| format!("Regex full match not found for {}", file_name))?
+                .as_str();
             matches
                 .entry(format!("{before}{after}"))
                 .or_default()
-                .push(capture.get(0).unwrap().as_str().to_string())
+                .push(full_match.to_string())
         }
     }
 
@@ -69,14 +84,21 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
 
         error!("Generating {playlist_file:?}");
 
-        let mut f = File::create(playlist_file.clone()).expect("Unable to create playlist");
+        let mut f = File::create(&playlist_file).map_err(|e| {
+            format!(
+                "Unable to create playlist {}: {}",
+                playlist_file.display(),
+                e
+            )
+        })?;
         for file in files {
-            match f.write_all(&file.clone().into_bytes()) {
-                Ok(_) => {}
-                Err(e) => {
-                    error!("{e}");
-                }
-            }
+            f.write_all(file.as_bytes()).map_err(|e| {
+                format!(
+                    "Failed to write to playlist {}: {}",
+                    playlist_file.display(),
+                    e
+                )
+            })?;
         }
     }
 

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -45,16 +45,25 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     let new_prefix = match replacement_root {
         Some(replacement_root) => replacement_root,
         None => {
-            let tmp = source.to_str().unwrap();
-            tmp.strip_suffix("/").unwrap_or(tmp).to_string()
+            let source_str = source
+                .to_str()
+                .ok_or_else(|| format!("Source path {} is not valid UTF-8", source.display()))?;
+            // Remove trailing slash if present
+            source_str
+                .strip_suffix("/")
+                .unwrap_or(source_str)
+                .to_string()
         }
     };
     debug!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
 
     let mut file_names = Vec::new();
-    for file in find_files_with_extension(&source, &["bin".to_string(), "cue".to_string()]) {
+    for file in find_files_with_extension(&source, &["bin".to_string(), "cue".to_string()])? {
         if let Some(file_name) = file.file_name() {
-            file_names.push(file_name.to_str().unwrap().to_string());
+            let file_name_str = file_name
+                .to_str()
+                .ok_or_else(|| format!("File name {} is not valid UTF-8", file.display()))?;
+            file_names.push(file_name_str.to_string());
         }
     }
 
@@ -66,30 +75,39 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     for file_name in &file_names {
         let old_path = source.join(file_name);
         let new_file_name = file_name.replace(&common, &new_prefix);
-        let new_path = source.join(new_file_name);
+        let new_path = source.join(&new_file_name);
 
-        match fs::rename(old_path, new_path.clone()) {
-            Ok(_) => (),
-            Err(e) => {
-                error!("{e}");
-            }
+        if let Err(e) = fs::rename(&old_path, &new_path) {
+            error!(
+                "Failed to rename {} to {}: {}",
+                old_path.display(),
+                new_path.display(),
+                e
+            );
+            continue;
         }
 
-        if new_path.extension().unwrap() == "cue" {
-            let contents = fs::read_to_string(new_path.clone()).unwrap();
-            let new = contents.replace(&common, &new_prefix);
-            match fs::OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .open(new_path.clone())
-            {
-                Ok(mut file) => {
-                    let _ = file.write(new.as_bytes());
-                }
-                Err(e) => {
-                    error!("{e}");
-                }
-            };
+        if let Some(ext) = new_path.extension() {
+            if ext == "cue" {
+                let contents = fs::read_to_string(&new_path).map_err(|e| {
+                    format!("Failed to read cue file {}: {}", new_path.display(), e)
+                })?;
+                let new = contents.replace(&common, &new_prefix);
+                let mut file = fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(&new_path)
+                    .map_err(|e| {
+                        format!(
+                            "Failed to open cue file {} for writing: {}",
+                            new_path.display(),
+                            e
+                        )
+                    })?;
+                file.write_all(new.as_bytes()).map_err(|e| {
+                    format!("Failed to write to cue file {}: {}", new_path.display(), e)
+                })?;
+            }
         }
     }
 


### PR DESCRIPTION
All panic-inducing operations (.unwrap(), .expect(), panic!()) are being
replaced with proper Result-based error handling.

Why is this important?

1. Reliability: Prevents unexpected program crashes from invalid input,
   missing files, or system errors. The program now fails gracefully
   with informative error messages instead of panicking.
2. Maintainability: Error handling is now explicit and traceable,
   making it easier to debug issues and understand failure modes.
3. Robustness: The codebase can now handle edge cases like non-UTF-8
   paths, missing commands, and file system errors without crashing.
4. Best practices: Follows Rust idioms for error handling using Result
   types, making the code more idiomatic and easier to work with.
