### PR TITLE
Optimize hot paths and reduce allocations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,19 +33,20 @@ impl Default for LinkConfig {
 
 impl LinkConfig {
     pub fn expand_destinations(&self) -> Vec<PathBuf> {
-        let mut destinations = Vec::new();
-        for destination in self.destinations.clone() {
-            destinations.push(PathBuf::from(if destination.starts_with("$") {
-                get_from_env_or_exit(&destination[1..])
-            } else {
-                destination
-            }));
-        }
-        destinations
+        self.destinations
+            .iter()
+            .map(|destination| {
+                PathBuf::from(if destination.starts_with('$') {
+                    get_from_env_or_exit(&destination[1..])
+                } else {
+                    destination.clone()
+                })
+            })
+            .collect()
     }
 
     pub fn expand_source(&self) -> PathBuf {
-        PathBuf::from(if self.source.starts_with("$") {
+        PathBuf::from(if self.source.starts_with('$') {
             get_from_env_or_exit(&self.source[1..])
         } else {
             self.source.clone()

--- a/src/games.rs
+++ b/src/games.rs
@@ -124,12 +124,15 @@ pub fn link(
 
         let destinations = system_config.get_destinations(system);
         for link_destination in destinations {
-            let mut path = destination.join(link_destination);
-            let mut current_system_source = system_source.clone();
-            if let Some(extra_path) = &system_config.extra_path {
-                current_system_source = system_source.join(extra_path);
-                path = path.join(extra_path);
-            }
+            let (current_system_source, path) = if let Some(extra_path) = &system_config.extra_path
+            {
+                (
+                    system_source.join(extra_path),
+                    destination.join(&link_destination).join(extra_path),
+                )
+            } else {
+                (system_source.clone(), destination.join(&link_destination))
+            };
             create_dir_all(&path)
                 .map_err(|e| format!("Failed to create directory {}: {}", path.display(), e))?;
             let _ = set_current_dir(&path).is_ok();

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -58,7 +58,8 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     debug!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
 
     let mut file_names = Vec::new();
-    for file in find_files_with_extension(&source, &["bin".to_string(), "cue".to_string()])? {
+    let bin_cue_ext = ["bin".to_string(), "cue".to_string()];
+    for file in find_files_with_extension(&source, &bin_cue_ext)? {
         if let Some(file_name) = file.file_name() {
             let file_name_str = file_name
                 .to_str()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,7 +51,7 @@ pub fn find_files_with_extension(
     for file in find_files(root)? {
         if let Some(extension) = file.extension() {
             if let Some(extension) = extension.to_str() {
-                if extensions.contains(&extension.to_string()) {
+                if extensions.iter().any(|ext| ext == extension) {
                     files_found.push(file);
                 }
             }


### PR DESCRIPTION
Apply several performance optimizations to reduce unnecessary
allocations and improve efficiency in frequently called code paths.

Regex patterns should only be compiled once. This is done using
`OnceLock`.

Containment can be checked with either `contains()` or
`iter().any(...)`. The latter avoids unnecessarily allocating a `String`
each time it's called. This is important when done inside a loop (like
in `find_files_with_extension`).

Using `map(...).collect()` can be more efficient than cloning the entire
vector as it will only clone the individual items when needed. The fewer
clones the better.

While the difference is minor, it's more efficient to compare characters
than it is to compare strings.
