### PR TITLE
Eliminate code duplication and simplify error handling

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -85,14 +85,12 @@ fn compress_to_chd(
     let output_path = dest.unwrap_or(PathBuf::new());
     debug!("Compressing from {source:?} to {output_path:?}");
 
-    let config: CompressConfig = match load_config_recursively(&source) {
-        Ok(config) => config,
-        Err(_) => {
+    let config: CompressConfig = load_config_recursively(&source)
+        .unwrap_or_else(|_| {
             debug!("No custom config found, using default compression settings");
             Config::default()
-        }
-    }
-    .compress;
+        })
+        .compress;
 
     let files_to_compress = find_files_with_extension(&source, &config.extensions)?;
 

--- a/src/games.rs
+++ b/src/games.rs
@@ -14,17 +14,15 @@ pub fn clean(
     all_systems: bool,
     dry_run: bool,
 ) -> Result<(), String> {
-    let changed = set_current_dir(Path::new(&destination));
-    if changed.is_err() {
-        return Err(format!("{:#?}", changed.err()));
-    }
+    set_current_dir(Path::new(destination)).map_err(|e| {
+        format!(
+            "Failed to change directory to {}: {}",
+            destination.display(),
+            e
+        )
+    })?;
 
-    let config = match load_link_destination_config(None) {
-        Ok(config) => config,
-        Err(e) => {
-            return Err(e);
-        }
-    };
+    let config = load_link_destination_config(None)?;
 
     let configured_systems = config.get_system_names();
     let systems_to_clean = if all_systems {
@@ -34,12 +32,9 @@ pub fn clean(
     };
 
     for system in systems_to_clean {
-        let system_config = match config.systems.get(system) {
-            Some(config) => config,
-            None => {
-                info!("{system} not found in config. Skipping.");
-                continue;
-            }
+        let Some(system_config) = config.systems.get(system) else {
+            info!("{system} not found in config. Skipping.");
+            continue;
         };
 
         let extensions = system_config.get_extensions(system);
@@ -84,17 +79,15 @@ pub fn link(
     systems: &[String],
     all_systems: bool,
 ) -> Result<(), String> {
-    let changed = set_current_dir(Path::new(&destination));
-    if changed.is_err() {
-        return Err(format!("{:#?}", changed.err()));
-    };
+    set_current_dir(Path::new(destination)).map_err(|e| {
+        format!(
+            "Failed to change directory to {}: {}",
+            destination.display(),
+            e
+        )
+    })?;
 
-    let config = match load_link_destination_config(None) {
-        Ok(config) => config,
-        Err(e) => {
-            return Err(e);
-        }
-    };
+    let config = load_link_destination_config(None)?;
 
     let configured_systems = config.get_system_names();
     let systems_to_link = if all_systems {
@@ -104,12 +97,9 @@ pub fn link(
     };
 
     for system in systems_to_link {
-        let system_config = match config.systems.get(system) {
-            Some(config) => config,
-            None => {
-                info!("{system} not found in config. Skipping.");
-                continue;
-            }
+        let Some(system_config) = config.systems.get(system) else {
+            info!("{system} not found in config. Skipping.");
+            continue;
         };
 
         let system_source = Path::new(&source).join(&system_config.dumper).join(&system);

--- a/src/link.rs
+++ b/src/link.rs
@@ -58,12 +58,7 @@ impl Args {
 }
 
 fn clean_links(systems: Vec<String>, all_systems: bool, dry_run: bool) -> Result<(), String> {
-    let config = match load_global_config() {
-        Ok(config) => config.link,
-        Err(e) => {
-            return Err(e);
-        }
-    };
+    let config = load_global_config()?.link;
 
     for destination in config.expand_destinations() {
         if let Err(e) = games::clean(&destination, &systems, all_systems, dry_run) {
@@ -75,12 +70,7 @@ fn clean_links(systems: Vec<String>, all_systems: bool, dry_run: bool) -> Result
 }
 
 fn link(systems: Vec<String>, all_systems: bool) -> Result<(), String> {
-    let config = match load_global_config() {
-        Ok(config) => config.link,
-        Err(e) => {
-            return Err(e);
-        }
-    };
+    let config = load_global_config()?.link;
 
     for destination in config.expand_destinations() {
         debug!("Linking games to {destination:?}");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -82,10 +82,7 @@ pub fn find_file_recursively(root: &Path, name: &str) -> Result<Option<PathBuf>,
 }
 
 pub fn get_from_env(name: &str) -> Result<String, VarError> {
-    match var(name) {
-        Ok(value) => Ok(value),
-        Err(e) => Err(e),
-    }
+    var(name)
 }
 
 pub fn get_from_env_or_exit(name: &str) -> String {


### PR DESCRIPTION
Replace verbose error handling patterns with idiomatic Rust using the
`?` operator and `let-else` patterns.

Some error handling used verbose match expressions with explicit
returns. This is being replaced with the `?` operator, which is the
standard Rust way to propagate errors. This reduces boilerplate and
makes the code more concise.

Directory change error handling in `games.rs` now uses `map_err` to
provide better error context, including the destination path in error
messages.

System config lookups in `games.rs` use the `let-else` pattern instead
of match expressions. This reduces nesting and makes early-return
patterns clearer.

`get_from_env` was just wrapping `var()` without any transformation, so
the wrapper is removed.
