### PR TITLE
Use more idiomatic types

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ impl LinkDestinationConfig {
 // instances of the struct so that 1) `system` doesn't need to be passed in as an argument and 2) I
 // don't have to resort to requiring `destination` and `extension` in each config entry.
 impl System {
-    pub fn get_destinations(&self, system: &String) -> Vec<String> {
+    pub fn get_destinations(&self, system: &str) -> Vec<String> {
         self.destinations.clone().unwrap_or_else(|| {
             vec![self
                 .destination
@@ -110,7 +110,7 @@ impl System {
         })
     }
 
-    pub fn get_extensions(&self, system: &String) -> Vec<String> {
+    pub fn get_extensions(&self, system: &str) -> Vec<String> {
         self.extensions
             .clone()
             .unwrap_or_else(|| vec![self.extension.clone().unwrap_or_else(|| system.to_string())])

--- a/src/games.rs
+++ b/src/games.rs
@@ -9,12 +9,12 @@ use super::config::load_link_destination_config;
 use super::utils::{capture_output, find_files_with_extension};
 
 pub fn clean(
-    destination: &PathBuf,
+    destination: &Path,
     systems: &[String],
     all_systems: bool,
     dry_run: bool,
 ) -> Result<(), String> {
-    set_current_dir(Path::new(destination)).map_err(|e| {
+    set_current_dir(destination).map_err(|e| {
         format!(
             "Failed to change directory to {}: {}",
             destination.display(),
@@ -74,12 +74,12 @@ pub fn clean(
 }
 
 pub fn link(
-    source: &PathBuf,
-    destination: &PathBuf,
+    source: &Path,
+    destination: &Path,
     systems: &[String],
     all_systems: bool,
 ) -> Result<(), String> {
-    set_current_dir(Path::new(destination)).map_err(|e| {
+    set_current_dir(destination).map_err(|e| {
         format!(
             "Failed to change directory to {}: {}",
             destination.display(),


### PR DESCRIPTION
Using these types allows both the original types and the new types to be
used. In the case of the `Path`, this also makes the calls to
`Path::new()` unnecessary.
