### PR TITLE
Make error messages more consistent

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -102,7 +102,7 @@ fn compress_to_chd(
     for file in files_to_compress {
         let file_name = file
             .file_name()
-            .ok_or_else(|| format!("File {} has no filename", file.display()))?;
+            .ok_or_else(|| format!("Failed to get filename for {}", file.display()))?;
         let mut output_file = output_path.join(file_name);
         output_file.set_extension("chd");
         if !force && output_file.exists() {
@@ -112,17 +112,20 @@ fn compress_to_chd(
 
         let file_str = file
             .to_str()
-            .ok_or_else(|| format!("File path {} is not valid UTF-8", file.display()))?;
-        let output_str = output_file
-            .to_str()
-            .ok_or_else(|| format!("Output path {} is not valid UTF-8", output_file.display()))?;
+            .ok_or_else(|| format!("Failed to convert file path {} to UTF-8", file.display()))?;
+        let output_str = output_file.to_str().ok_or_else(|| {
+            format!(
+                "Failed to convert output path {} to UTF-8",
+                output_file.display()
+            )
+        })?;
 
         let mut command = require_command("chdman")?;
         command.args(&[image_format, "-i", file_str, "-o", output_str]);
         if force {
             command.arg("--force");
         }
-        let error_message = format!("Could not compress {file:?}");
+        let error_message = format!("Failed to compress {}", file.display());
 
         if log_enabled!(Level::Warn) {
             stream_output(&mut command, &error_message)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,7 +121,7 @@ pub fn load_config_recursively<T: serde::Serialize + serde::de::DeserializeOwned
     root: &Path,
 ) -> Result<T, String> {
     let path = find_file_recursively(root, "retro.toml")?
-        .ok_or_else(|| "No retro.toml file found".to_string())?;
+        .ok_or_else(|| "Failed to find retro.toml file".to_string())?;
     let path_display = path.display();
     confy::load_path(&path)
         .map_err(|e| format!("Failed to load config from {}: {}", path_display, e))

--- a/src/games.rs
+++ b/src/games.rs
@@ -139,7 +139,7 @@ pub fn link(
             for file in &files_to_link {
                 let destination_file_name = file
                     .file_name()
-                    .ok_or_else(|| format!("File {} has no filename", file.display()))?;
+                    .ok_or_else(|| format!("Failed to get filename for {}", file.display()))?;
                 let destination_path = path.join(destination_file_name);
                 if destination_path.exists() {
                     let metadata = symlink_metadata(&destination_path).map_err(|e| {
@@ -158,9 +158,9 @@ pub fn link(
                         }
                     }
                 }
-                let file_str = file
-                    .to_str()
-                    .ok_or_else(|| format!("File path {} is not valid UTF-8", file.display()))?;
+                let file_str = file.to_str().ok_or_else(|| {
+                    format!("Failed to convert file path {} to UTF-8", file.display())
+                })?;
                 let output = capture_output(
                     &mut Command::new("ln").args(["-s", "-F", "-f", "-v", file_str]),
                     "Failed to link",

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     exit(match cli::dispatch() {
         Ok(_) => 0,
         Err(e) => {
-            error!("error: {:?}", e);
+            error!("{}", e);
             1
         }
     });

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -58,22 +58,22 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
     for file in find_files_with_extension(&source, &chd_ext)? {
         let file_name = file
             .file_name()
-            .ok_or_else(|| format!("File {} has no filename", file.display()))?
+            .ok_or_else(|| format!("Failed to get filename for {}", file.display()))?
             .to_str()
-            .ok_or_else(|| format!("File name {} is not valid UTF-8", file.display()))?;
+            .ok_or_else(|| format!("Failed to convert file name {} to UTF-8", file.display()))?;
         let capture = re.captures(file_name);
         if let Some(capture) = capture {
             let before = capture
                 .name("before")
-                .ok_or_else(|| format!("Regex capture 'before' not found for {}", file_name))?
+                .ok_or_else(|| format!("Failed to find regex capture 'before' for {}", file_name))?
                 .as_str();
             let after = capture
                 .name("after")
-                .ok_or_else(|| format!("Regex capture 'after' not found for {}", file_name))?
+                .ok_or_else(|| format!("Failed to find regex capture 'after' for {}", file_name))?
                 .as_str();
             let full_match = capture
                 .get(0)
-                .ok_or_else(|| format!("Regex full match not found for {}", file_name))?
+                .ok_or_else(|| format!("Failed to find regex full match for {}", file_name))?
                 .as_str();
             matches
                 .entry(format!("{before}{after}"))
@@ -92,7 +92,7 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
 
         let mut f = File::create(&playlist_file).map_err(|e| {
             format!(
-                "Unable to create playlist {}: {}",
+                "Failed to create playlist {}: {}",
                 playlist_file.display(),
                 e
             )

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -45,9 +45,12 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     let new_prefix = match replacement_root {
         Some(replacement_root) => replacement_root,
         None => {
-            let source_str = source
-                .to_str()
-                .ok_or_else(|| format!("Source path {} is not valid UTF-8", source.display()))?;
+            let source_str = source.to_str().ok_or_else(|| {
+                format!(
+                    "Failed to convert source path {} to UTF-8",
+                    source.display()
+                )
+            })?;
             // Remove trailing slash if present
             source_str
                 .strip_suffix("/")
@@ -61,16 +64,16 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     let bin_cue_ext = ["bin".to_string(), "cue".to_string()];
     for file in find_files_with_extension(&source, &bin_cue_ext)? {
         if let Some(file_name) = file.file_name() {
-            let file_name_str = file_name
-                .to_str()
-                .ok_or_else(|| format!("File name {} is not valid UTF-8", file.display()))?;
+            let file_name_str = file_name.to_str().ok_or_else(|| {
+                format!("Failed to convert file name {} to UTF-8", file.display())
+            })?;
             file_names.push(file_name_str.to_string());
         }
     }
 
     let common = longest_common_prefix(&file_names);
     if common.is_empty() {
-        return Err("No common prefix found".to_string());
+        return Err("Failed to find common prefix".to_string());
     }
 
     for file_name in &file_names {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,7 @@ pub fn capture_output<'a>(
         .map_err(|e| format!("{}: {}", expected_message, e))?;
 
     let result = String::from_utf8(output.stdout)
-        .map_err(|e| format!("Invalid UTF-8 sequence in command output: {}", e))?;
+        .map_err(|e| format!("Failed to decode UTF-8 in command output: {}", e))?;
 
     Ok(result.trim().to_string())
 }
@@ -121,7 +121,7 @@ pub fn require_command(command: &str) -> Result<Command, String> {
         }
     }
 
-    Err(format!("Command '{}' not found in PATH", command))
+    Err(format!("Failed to find command '{}' in PATH", command))
 }
 
 pub fn stream_output(command: &mut Command, expected_message: &str) -> Result<(), String> {
@@ -135,7 +135,7 @@ pub fn stream_output(command: &mut Command, expected_message: &str) -> Result<()
 
     if !exit_status.success() {
         let code = exit_status.code().unwrap_or(1);
-        return Err(format!("Command failed with exit code {}", code));
+        return Err(format!("Failed to execute command: exit code {}", code));
     }
 
     Ok(())


### PR DESCRIPTION
The structure of the error messages is a bit all over. This standardizes
them to all started with "Failed to" as this will make it easy to grep
the output/logs when there's a problem.
