### PR TITLE
Optimize allocations and ownership patterns

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -92,7 +92,8 @@ fn compress_to_chd(
         })
         .compress;
 
-    let files_to_compress = find_files_with_extension(&source, &config.extensions)?;
+    let extensions: Vec<&str> = config.extensions.iter().map(|s| s.as_str()).collect();
+    let files_to_compress = find_files_with_extension(&source, &extensions)?;
 
     let mut image_format: &str = &format!("create{}", config.format);
     if as_dvd {

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,21 +36,21 @@ impl LinkConfig {
         self.destinations
             .iter()
             .map(|destination| {
-                PathBuf::from(if destination.starts_with('$') {
-                    get_from_env_or_exit(&destination[1..])
+                if destination.starts_with('$') {
+                    PathBuf::from(get_from_env_or_exit(&destination[1..]))
                 } else {
-                    destination.clone()
-                })
+                    PathBuf::from(destination.as_str())
+                }
             })
             .collect()
     }
 
     pub fn expand_source(&self) -> PathBuf {
-        PathBuf::from(if self.source.starts_with('$') {
-            get_from_env_or_exit(&self.source[1..])
+        if self.source.starts_with('$') {
+            PathBuf::from(get_from_env_or_exit(&self.source[1..]))
         } else {
-            self.source.clone()
-        })
+            PathBuf::from(self.source.as_str())
+        }
     }
 }
 
@@ -92,7 +92,7 @@ impl Default for System {
 
 impl LinkDestinationConfig {
     pub fn get_system_names(&self) -> Vec<String> {
-        Vec::from_iter(self.systems.keys().map(|k| k.to_string()))
+        self.systems.keys().map(|k| k.clone()).collect()
     }
 }
 
@@ -102,18 +102,23 @@ impl LinkDestinationConfig {
 // don't have to resort to requiring `destination` and `extension` in each config entry.
 impl System {
     pub fn get_destinations(&self, system: &str) -> Vec<String> {
-        self.destinations.clone().unwrap_or_else(|| {
-            vec![self
-                .destination
-                .clone()
-                .unwrap_or_else(|| system.to_string())]
-        })
+        if let Some(ref destinations) = self.destinations {
+            destinations.clone()
+        } else if let Some(ref destination) = self.destination {
+            vec![destination.clone()]
+        } else {
+            vec![system.to_string()]
+        }
     }
 
     pub fn get_extensions(&self, system: &str) -> Vec<String> {
-        self.extensions
-            .clone()
-            .unwrap_or_else(|| vec![self.extension.clone().unwrap_or_else(|| system.to_string())])
+        if let Some(ref extensions) = self.extensions {
+            extensions.clone()
+        } else if let Some(ref extension) = self.extension {
+            vec![extension.clone()]
+        } else {
+            vec![system.to_string()]
+        }
     }
 }
 

--- a/src/games.rs
+++ b/src/games.rs
@@ -48,7 +48,8 @@ pub fn clean(
             let _ = set_current_dir(&path).is_ok();
             debug!("Checking for broken {extensions:?} links in {path:?}.");
 
-            let files_to_clean = find_files_with_extension(&path, &extensions)?;
+            let extensions_slice: Vec<&str> = extensions.iter().map(|s| s.as_str()).collect();
+            let files_to_clean = find_files_with_extension(&path, &extensions_slice)?;
 
             for file in &files_to_clean {
                 let metadata = symlink_metadata(file)
@@ -110,7 +111,8 @@ pub fn link(
 
         let extensions = system_config.get_extensions(system);
 
-        let files_to_link = find_files_with_extension(&system_source, &extensions)?;
+        let extensions_slice: Vec<&str> = extensions.iter().map(|s| s.as_str()).collect();
+        let files_to_link = find_files_with_extension(&system_source, &extensions_slice)?;
 
         let destinations = system_config.get_destinations(system);
         for link_destination in destinations {
@@ -121,6 +123,8 @@ pub fn link(
                     destination.join(&link_destination).join(extra_path),
                 )
             } else {
+                // Clone is necessary here since we need an owned PathBuf and
+                // system_source must be reused for the next iteration
                 (system_source.clone(), destination.join(&link_destination))
             };
             create_dir_all(&path)

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -54,7 +54,7 @@ fn generate_m3u_playlists(source: PathBuf) -> Result<(), String> {
 
     let mut matches: HashMap<String, Vec<String>> = HashMap::new();
 
-    let chd_ext = ["chd".to_string()];
+    let chd_ext = ["chd"];
     for file in find_files_with_extension(&source, &chd_ext)? {
         let file_name = file
             .file_name()

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -61,7 +61,7 @@ fn rename_bin_cue_files(source: PathBuf, replacement_root: Option<String>) -> Re
     debug!("Renaming all bin and cue files in \"{source:?}\" to start with \"{new_prefix}\"");
 
     let mut file_names = Vec::new();
-    let bin_cue_ext = ["bin".to_string(), "cue".to_string()];
+    let bin_cue_ext = ["bin", "cue"];
     for file in find_files_with_extension(&source, &bin_cue_ext)? {
         if let Some(file_name) = file.file_name() {
             let file_name_str = file_name.to_str().ok_or_else(|| {


### PR DESCRIPTION
This reduces unnecessary allocations by accepting string slices instead
of owned strings where possible, avoiding clones when references
suffice, and using in-place operations instead of creating new
allocations. These changes improve performance by reducing memory
allocations and copying, particularly in hot paths like file searching
and configuration expansion.
